### PR TITLE
CCE Node data encryption for provider >= 1.24.3

### DIFF
--- a/modules/cce/main.tf
+++ b/modules/cce/main.tf
@@ -44,6 +44,7 @@ resource "opentelekomcloud_cce_node_v3" "nodes" {
   data_volumes {
     size       = var.nodes_data_volume_size
     volumetype = var.nodes_data_volume_type
+    kms_id     = var.node_data_encryption_key_id
   }
   root_volume {
     size       = var.nodes_root_volume_size

--- a/modules/cce/variables.tf
+++ b/modules/cce/variables.tf
@@ -83,3 +83,9 @@ variable "cce_version" {
 variable "cce_authentication_mode" {
   default = "rbac"
 }
+
+variable "node_data_encryption_key_id" {
+  type        = string
+  default     = null
+  description = "KMS Key ID for the encryption of CCE node data volumes."
+}

--- a/modules/cce/versions.tf
+++ b/modules/cce/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     opentelekomcloud = {
       source  = "opentelekomcloud/opentelekomcloud"
-      version = ">=1.23.12"
+      version = ">=1.24.3"
     }
   }
 

--- a/modules/cce_autoscaling/node_pool_autoscale.tf
+++ b/modules/cce_autoscaling/node_pool_autoscale.tf
@@ -24,6 +24,7 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool_autoscale" {
   data_volumes {
     size       = var.nodes_data_volume_size
     volumetype = var.nodes_data_volume_type
+    kms_id     = var.node_data_encryption_key_id
   }
 
   lifecycle {

--- a/modules/cce_autoscaling/variables.tf
+++ b/modules/cce_autoscaling/variables.tf
@@ -84,6 +84,12 @@ variable "nodes_os" {
   type    = string
 }
 
+variable "node_data_encryption_key_id" {
+  type        = string
+  default     = null
+  description = "KMS Key ID for the encryption of CCE node data volumes."
+}
+
 locals {
   node_pool_name = var.node_pool_name == null ? "${var.cce_name}-node-pool-autoscale" : var.node_pool_name
 }

--- a/modules/cce_autoscaling/versions.tf
+++ b/modules/cce_autoscaling/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_providers {
     opentelekomcloud = {
       source  = "opentelekomcloud/opentelekomcloud"
-      version = ">=1.23.12"
+      version = ">=1.24.3"
+      # provider version 1.24.1 and 1.24.2 have a bug that prevents the node pool from creation.
     }
   }
 


### PR DESCRIPTION
Default Encryption for CCE node data volumes. 
We need Terraform OTC Provider 1.24.3 for this. See https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1161