### PR TITLE
closes #18

### DIFF
--- a/modules/cce/kubectl.tf
+++ b/modules/cce/kubectl.tf
@@ -26,7 +26,7 @@ locals {
         name = "${var.context_name}-${var.stage_name}"
       },
     ]
-    current-context = var.stage_name
+    current-context = "${var.context_name}-${var.stage_name}"
     kind            = "Config"
     preferences     = {}
     users = [


### PR DESCRIPTION
give "current-context" and newly created context the same name