### PR TITLE
cce: add variable for metric server version

### DIFF
--- a/modules/cce/metrics.tf
+++ b/modules/cce/metrics.tf
@@ -1,6 +1,6 @@
 resource "opentelekomcloud_cce_addon_v3" "metrics" {
   template_name    = "metrics-server"
-  template_version = "1.0.6"
+  template_version = var.addon_metric_server_version
   cluster_id       = opentelekomcloud_cce_cluster_v3.cluster.id
 
   values {

--- a/modules/cce/variables.tf
+++ b/modules/cce/variables.tf
@@ -89,3 +89,9 @@ variable "node_data_encryption_key_id" {
   default     = null
   description = "KMS Key ID for the encryption of CCE node data volumes."
 }
+
+variable "addon_metric_server_version" {
+  type        = string
+  default     = "1.0.6"
+  description = "Version for Metric-Server addon."
+}


### PR DESCRIPTION
Cluster already have version 1.1.4 available (at least in NL). Therefore the version of the addon should be a variable. 