### PR TITLE
CCE: create one node pool for each availability zone

### DIFF
--- a/modules/cce/cluster.tf
+++ b/modules/cce/cluster.tf
@@ -61,7 +61,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster" {
 resource "opentelekomcloud_cce_node_pool_v3" "cluster_node_pool" {
   count              = length(local.node_config.availability_zones)
   cluster_id         = opentelekomcloud_cce_cluster_v3.cluster.id
-  name               = "${var.name}-node-pool-az-${local.node_config.availability_zones[count.index]}"
+  name               = "${var.name}-nodes-${local.node_config.availability_zones[count.index]}"
   flavor             = local.node_config.node_flavor
   initial_node_count = local.node_config.node_count
   availability_zone  = local.node_config.availability_zones[count.index]

--- a/modules/cce/cluster.tf
+++ b/modules/cce/cluster.tf
@@ -59,11 +59,12 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster" {
 }
 
 resource "opentelekomcloud_cce_node_pool_v3" "cluster_node_pool" {
+  count              = length(local.node_config.availability_zones)
   cluster_id         = opentelekomcloud_cce_cluster_v3.cluster.id
-  name               = "${var.name}-node-pool"
+  name               = "${var.name}-node-pool-az-${local.node_config.availability_zones[count.index]}"
   flavor             = local.node_config.node_flavor
   initial_node_count = local.node_config.node_count
-  availability_zone  = local.node_config.availability_zones[0]
+  availability_zone  = local.node_config.availability_zones[count.index]
   key_pair           = opentelekomcloud_compute_keypair_v2.cluster_keypair.name
   os                 = local.node_config.node_os
 

--- a/modules/cce/output.tf
+++ b/modules/cce/output.tf
@@ -2,7 +2,7 @@ output "cluster_lb_public_ip" {
   value = opentelekomcloud_vpc_eip_v1.cce_eip.publicip[0].ip_address
 }
 
-output "node_pool_id" {
+output "node_pool_ids" {
   value = opentelekomcloud_cce_node_pool_v3.cluster_node_pool[*].id
 }
 

--- a/modules/cce/output.tf
+++ b/modules/cce/output.tf
@@ -3,7 +3,7 @@ output "cluster_lb_public_ip" {
 }
 
 output "node_pool_id" {
-  value = ["${opentelekomcloud_cce_node_pool_v3.cluster_node_pool.*.id}"]
+  value = opentelekomcloud_cce_node_pool_v3.cluster_node_pool[*].id
 }
 
 output "cluster_credentials" {

--- a/modules/cce/output.tf
+++ b/modules/cce/output.tf
@@ -3,7 +3,7 @@ output "cluster_lb_public_ip" {
 }
 
 output "node_pool_id" {
-  value = opentelekomcloud_cce_node_pool_v3.cluster_node_pool.id
+  value = ["${opentelekomcloud_cce_node_pool_v3.cluster_node_pool.*.id}"]
 }
 
 output "cluster_credentials" {

--- a/modules/cce/variables.tf
+++ b/modules/cce/variables.tf
@@ -56,7 +56,7 @@ locals {
 variable "node_config" {
   description = "Cluster node configuration parameters"
   type = object({
-    availability_zones              = optional(list(string)) // Availability zones for the node pools. Providing multiple, creates one node pool in each availability zone. (default: ["eu-de-03"])
+    availability_zones              = optional(list(string)) // Availability zones for the node pools. Providing multiple availability zones creates one node pool in each zone. (default: ["eu-de-03"])
     node_count                      = number                 // Number of nodes to create
     node_flavor                     = string                 // Node specifications in otc flavor format
     node_os                         = optional(string)       // Operating system of worker nodes: EulerOS 2.5 or CentOS 7.7 (default: EulerOS 2.5)

--- a/modules/cce/variables.tf
+++ b/modules/cce/variables.tf
@@ -56,7 +56,7 @@ locals {
 variable "node_config" {
   description = "Cluster node configuration parameters"
   type = object({
-    availability_zones              = optional(list(string)) // Availability zones for the node pool (default: ["eu-de-03"])
+    availability_zones              = optional(list(string)) // Availability zones for the node pools. Providing multiple, creates one node pool in each availability zone. (default: ["eu-de-03"])
     node_count                      = number                 // Number of nodes to create
     node_flavor                     = string                 // Node specifications in otc flavor format
     node_os                         = optional(string)       // Operating system of worker nodes: EulerOS 2.5 or CentOS 7.7 (default: EulerOS 2.5)


### PR DESCRIPTION
Hello iits team,

We noticed that one can define a list of availability zones (az) for the variable `node_config.availability_zones` in the CCE module. When doing so only one node pool is created and the first item in the list is used in the config.

In this PR, I simply added a `count` to the terraform module to make sure one node pool is created for each az.
This adds real high availability to the CCE cluster in case one OTC az goes down.

I was able to test this successfully. The existing node pool was renamed in-place (not destroyed and recreated).

Hope this is helpful
Cheers Karsten

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202689898421397