### PR TITLE
Enhancement: allow usage of existing kms key for node storage encryption

### DIFF
--- a/modules/cce/cluster.tf
+++ b/modules/cce/cluster.tf
@@ -92,13 +92,13 @@ resource "opentelekomcloud_cce_node_pool_v3" "cluster_node_pool" {
   root_volume {
     size       = 50
     volumetype = "SSD"
-    kms_id     = var.node_storage_encryption_enabled ? ( var.node_storage_encryption_kms_key_name == null ? opentelekomcloud_kms_key_v1.node_storage_encryption_key[0].id : data.opentelekomcloud_kms_key_v1.node_storage_encryption_existing_key[0].id ) : null
+    kms_id     = var.node_storage_encryption_enabled ? (var.node_storage_encryption_kms_key_name == null ? opentelekomcloud_kms_key_v1.node_storage_encryption_key[0].id : data.opentelekomcloud_kms_key_v1.node_storage_encryption_existing_key[0].id) : null
   }
 
   data_volumes {
     size       = var.node_storage_size
     volumetype = var.node_storage_type
-    kms_id     = var.node_storage_encryption_enabled ? ( var.node_storage_encryption_kms_key_name == null ? opentelekomcloud_kms_key_v1.node_storage_encryption_key[0].id : data.opentelekomcloud_kms_key_v1.node_storage_encryption_existing_key[0].id ) : null
+    kms_id     = var.node_storage_encryption_enabled ? (var.node_storage_encryption_kms_key_name == null ? opentelekomcloud_kms_key_v1.node_storage_encryption_key[0].id : data.opentelekomcloud_kms_key_v1.node_storage_encryption_existing_key[0].id) : null
   }
 
   lifecycle {

--- a/modules/cce/cluster.tf
+++ b/modules/cce/cluster.tf
@@ -92,13 +92,13 @@ resource "opentelekomcloud_cce_node_pool_v3" "cluster_node_pool" {
   root_volume {
     size       = 50
     volumetype = "SSD"
-    kms_id     = var.node_storage_encryption_enabled ? coalesce(data.opentelekomcloud_kms_key_v1.node_storage_encryption_existing_key[0].id, opentelekomcloud_kms_key_v1.node_storage_encryption_key[0].id) : null
+    kms_id     = var.node_storage_encryption_enabled ? ( var.node_storage_encryption_kms_key_name == null ? opentelekomcloud_kms_key_v1.node_storage_encryption_key[0].id : data.opentelekomcloud_kms_key_v1.node_storage_encryption_existing_key[0].id ) : null
   }
 
   data_volumes {
     size       = var.node_storage_size
     volumetype = var.node_storage_type
-    kms_id     = var.node_storage_encryption_enabled ? coalesce(data.opentelekomcloud_kms_key_v1.node_storage_encryption_existing_key[0].id, opentelekomcloud_kms_key_v1.node_storage_encryption_key[0].id) : null
+    kms_id     = var.node_storage_encryption_enabled ? ( var.node_storage_encryption_kms_key_name == null ? opentelekomcloud_kms_key_v1.node_storage_encryption_key[0].id : data.opentelekomcloud_kms_key_v1.node_storage_encryption_existing_key[0].id ) : null
   }
 
   lifecycle {

--- a/modules/cce/variables.tf
+++ b/modules/cce/variables.tf
@@ -174,6 +174,12 @@ variable "node_storage_encryption_enabled" {
   default     = false
 }
 
+variable "node_storage_encryption_kms_key_name" {
+  type        = string
+  description = "If KMS volume encryption is enabled, specify a name of an existing kms key. Setting this disables the creation of a new kms key. (default: null)"
+  default     = null
+}
+
 variable "node_postinstall" {
   type        = string
   description = "Post install script for the cluster ECS node pool."

--- a/modules/jumphost/node.tf
+++ b/modules/jumphost/node.tf
@@ -24,7 +24,7 @@ resource "opentelekomcloud_blockstorage_volume_v2" "jumphost_boot_volume" {
     readonly      = "False"
     }, local.node_storage_encryption_enabled ? {
     __system__encrypted = "1"
-    __system__cmkid     = opentelekomcloud_kms_key_v1.jumphost_storage_encryption_key[0].id
+    __system__cmkid     = var.node_storage_encryption_key_name == null ? opentelekomcloud_kms_key_v1.jumphost_storage_encryption_key[0].id : data.opentelekomcloud_kms_key_v1.jumphost_storage_existing_encryption_key[0].id
   } : {})
   tags = var.tags
   lifecycle {

--- a/modules/jumphost/security.tf
+++ b/modules/jumphost/security.tf
@@ -1,14 +1,19 @@
 resource "random_id" "jumphost_storage_encryption_key" {
-  count       = local.node_storage_encryption_enabled ? 1 : 0
+  count       = local.node_storage_encryption_enabled && var.node_storage_encryption_key_name == null ? 1 : 0
   byte_length = 4
 }
 
 resource "opentelekomcloud_kms_key_v1" "jumphost_storage_encryption_key" {
-  count           = local.node_storage_encryption_enabled ? 1 : 0
+  count           = local.node_storage_encryption_enabled && var.node_storage_encryption_key_name == null ? 1 : 0
   key_alias       = "${var.node_name}-${random_id.jumphost_storage_encryption_key[0].hex}"
   key_description = "${var.node_name} Jumphost Node system volume encryption key"
   pending_days    = 7
   is_enabled      = "true"
+}
+
+data "opentelekomcloud_kms_key_v1" "jumphost_storage_existing_encryption_key" {
+  count     = local.node_storage_encryption_enabled && var.node_storage_encryption_key_name != null ? 1 : 0
+  key_alias = var.node_storage_encryption_key_name
 }
 
 resource "opentelekomcloud_networking_secgroup_v2" "jumphost_secgroup" {

--- a/modules/jumphost/variables.tf
+++ b/modules/jumphost/variables.tf
@@ -45,6 +45,12 @@ variable "node_storage_encryption_enabled" {
   default     = false
 }
 
+variable "node_storage_encryption_key_name" {
+  type = string
+  description = "If jumphost system disk KMS encryption is enabled, use this KMS key name instead of creating a new one."
+  default     = null
+}
+
 locals {
   node_storage_encryption_enabled = data.opentelekomcloud_identity_project_v3.current.region != "eu-de" ? false : var.node_storage_encryption_enabled
 }

--- a/modules/jumphost/variables.tf
+++ b/modules/jumphost/variables.tf
@@ -46,7 +46,7 @@ variable "node_storage_encryption_enabled" {
 }
 
 variable "node_storage_encryption_key_name" {
-  type = string
+  type        = string
   description = "If jumphost system disk KMS encryption is enabled, use this KMS key name instead of creating a new one."
   default     = null
 }

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -200,6 +200,12 @@ variable "db_volume_encryption" {
   default     = true
 }
 
+variable "db_volume_encryption_key_name" {
+  type        = string
+  description = "If KMS volume encryption is enabled for the database volumes, use this kms key name instead of creating a new one. (default: null)"
+  default     = null
+}
+
 variable "sg_allowed_cidr" {
   type        = set(string)
   description = "CIDR ranges that are allowed to connect to the database. (default: <var.subnet_id.cidr>)"


### PR DESCRIPTION
Hi iits Team,

I'd like to suggest following enhancement. We have a shared responsibility approach. So we need to use an existing kms key for node pool storage encryption.

This PR adds an optional variable `node_storage_encryption_kms_key_name` that can be used for encryption, without the need for the cce module to create a dedicated kms key. 

I tested the backward-compatibility successfully.