### PR TITLE
AutoScaling issues: add optional node pool with different flavor

### DIFF
--- a/modules/cce/variables.tf
+++ b/modules/cce/variables.tf
@@ -150,6 +150,12 @@ variable "node_flavor" {
   description = "Node specifications in otc flavor format"
 }
 
+variable "node_additional_flavors" {
+  type        = list(string)
+  description = "If you need even more reliability and availability, you can create an additional node group set with these flavors in case your primary flavor is sold out and unable to scale. For example: ['s2.2xlarge.2', 'c4.2xlarge.2']. (default: [] )"
+  default     = []
+}
+
 variable "node_os" {
   type        = string
   description = "Operating system of worker nodes: EulerOS 2.5 or CentOS 7.7 (default: EulerOS 2.9)"


### PR DESCRIPTION
Hi iits Team,

first, as always: thanks a million for maintaining this library. We're happy to use and improve it.

We are facing a severe issue with the CCE auto-scaling feature. Due to resource shortage in OTC we had the situation where CCE node pool autoscaling failed in AZ `eu-de-02` for node flavor `s3.2xlarge.2`. 
So it seems, it's not a good idea to rely only on one worker node flavor.

The enhancement in this PR is for the case where you really need reliability and high availability.
When you set the optional variable `node_additional_flavors` an additional node pool is created in each of the AZs in `node_availability_zones`. This makes sure you work load is distributed over several AZs **and** flavors.
If there is a shortage on certain flavors in OTC, the cluster does not stop to scale.

I tested and put extra effort in this PR to be completely backwards-compatible.

Please, let me know what you think.
Cheers Karsten