### PR TITLE
add output node pool keypair name

### DIFF
--- a/modules/cce/output.tf
+++ b/modules/cce/output.tf
@@ -15,6 +15,10 @@ output "node_pool_ids" {
   value = { for node_pool in opentelekomcloud_cce_node_pool_v3.cluster_node_pool : node_pool.name => node_pool.id }
 }
 
+output "node_pool_keypair_name" {
+  value = opentelekomcloud_compute_keypair_v2.cluster_keypair.name
+}
+
 output "cluster_credentials" {
   value = {
     kubectl_config                     = local.kubectl_config_yaml


### PR DESCRIPTION
This is needed when adding additional node pools to clusters created by cce module. (refer to discussion in [PR#66](https://github.com/iits-consulting/terraform-opentelekomcloud-project-factory/pull/66))