### PR TITLE
CCE (BREAKING)

### DIFF
--- a/modules/cce/cluster.tf
+++ b/modules/cce/cluster.tf
@@ -1,15 +1,9 @@
-resource "tls_private_key" "cluster_keypair" {
-  algorithm   = "ECDSA"
-  ecdsa_curve = "P256"
-}
-
-resource "random_id" "cluster_keypair_id" {
-  byte_length = 4
-}
-
-resource "opentelekomcloud_compute_keypair_v2" "cluster_keypair" {
-  name       = "${var.name}-cluster-keypair-${random_id.cluster_keypair_id.hex}"
-  public_key = tls_private_key.cluster_keypair.public_key_openssh
+resource "random_password" "node_password" {
+  length      = 32
+  special     = false
+  min_lower   = 1
+  min_numeric = 1
+  min_upper   = 1
 }
 
 resource "opentelekomcloud_vpc_eip_v1" "cce_eip" {
@@ -77,7 +71,7 @@ resource "opentelekomcloud_cce_node_pool_v3" "cluster_node_pool" {
   flavor             = var.node_flavor
   initial_node_count = var.node_count
   availability_zone  = each.value
-  key_pair           = opentelekomcloud_compute_keypair_v2.cluster_keypair.name
+  password           = var.node_password == "" ? random_password.node_password.result : var.node_password
   os                 = var.node_os
   runtime            = var.node_container_runtime
 

--- a/modules/cce/output.tf
+++ b/modules/cce/output.tf
@@ -15,18 +15,8 @@ output "node_pool_ids" {
   value = { for node_pool in opentelekomcloud_cce_node_pool_v3.cluster_node_pool : node_pool.name => node_pool.id }
 }
 
-output "node_pool_keypair_name" {
-  value = opentelekomcloud_compute_keypair_v2.cluster_keypair.name
-}
-
-output "node_pool_keypair_private_key" {
-  sensitive = true
-  value     = tls_private_key.cluster_keypair.private_key_openssh
-}
-
-output "node_pool_keypair_public_key" {
-  sensitive = true
-  value     = tls_private_key.cluster_keypair.public_key_openssh
+output "node_password" {
+  value = var.node_password == "" ? random_password.node_password.result : var.node_password
 }
 
 output "cluster_credentials" {

--- a/modules/cce/variables.tf
+++ b/modules/cce/variables.tf
@@ -163,7 +163,7 @@ variable "node_container_runtime" {
 }
 
 variable "node_password" {
-  type        = number
+  type        = string
   description = "Password to access the nodes directly. Default: (32 Character Alphanumeric Random Generated)"
   default     = ""
 }

--- a/modules/cce/variables.tf
+++ b/modules/cce/variables.tf
@@ -162,6 +162,12 @@ variable "node_container_runtime" {
   default     = null
 }
 
+variable "node_password" {
+  type        = number
+  description = "Password to access the nodes directly. Default: (32 Character Alphanumeric Random Generated)"
+  default     = ""
+}
+
 variable "node_storage_type" {
   type        = string
   description = "Type of node storage SATA, SAS or SSD (default: SATA)"
@@ -244,4 +250,3 @@ variable "authentication_mode" {
   description = "rbac or x509"
   default     = "x509"
 }
-


### PR DESCRIPTION
CCE (BREAKING): disabled keypair and replaced it with password for cce node pools. This allows pools to behave user agnostic as key pairs on OTC are user specific.