### PR TITLE
cce: support container runtime setting in node pool

### DIFF
--- a/modules/cce/cluster.tf
+++ b/modules/cce/cluster.tf
@@ -79,6 +79,7 @@ resource "opentelekomcloud_cce_node_pool_v3" "cluster_node_pool" {
   availability_zone  = each.value
   key_pair           = opentelekomcloud_compute_keypair_v2.cluster_keypair.name
   os                 = var.node_os
+  runtime            = var.node_container_runtime
 
   scale_enable             = var.cluster_enable_scaling
   min_node_count           = local.autoscaler_node_min

--- a/modules/cce/variables.tf
+++ b/modules/cce/variables.tf
@@ -156,6 +156,12 @@ variable "node_os" {
   default     = "EulerOS 2.9"
 }
 
+variable "node_container_runtime" {
+  type        = string
+  description = "The container runtime to use. If not set OTC default will be used"
+  default     = null
+}
+
 variable "node_storage_type" {
   type        = string
   description = "Type of node storage SATA, SAS or SSD (default: SATA)"
@@ -238,3 +244,4 @@ variable "authentication_mode" {
   description = "rbac or x509"
   default     = "x509"
 }
+


### PR DESCRIPTION
If not set the default option of OTC will be used.