### PR TITLE
Generate parts of the documentation with terraform-docs

### DIFF
--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -1,0 +1,19 @@
+name: Terraform documentation generation
+
+on:
+  - pull_request
+
+jobs:
+  terraform-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v3
+
+      - name: Render terraform docs and push changes back to PR
+        uses: terraform-docs/gh-actions@main
+        with:
+          config-file: .terraform-docs.yaml
+          git-push: "true"

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -15,6 +15,8 @@ jobs:
       - if: ${{ !env.ACT }}
         name: Clone repo
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - uses: dorny/paths-filter@v2
         id: changes
@@ -23,6 +25,7 @@ jobs:
             tf:
               - '**/*.tf'
               - '**/README.md'
+
       - if: steps.changes.outputs.tf == 'true'
         name: Render terraform docs and push changes back to PR
         uses: terraform-docs/gh-actions@main

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -1,18 +1,30 @@
 name: Terraform documentation generation
 
 on:
-  - pull_request
-
+  pull_request:
+    types:
+      - opened
+      - synchronize
 jobs:
   terraform-docs:
     runs-on: ubuntu-latest
     permissions:
+      pull-requests: read
       contents: write
     steps:
-      - name: Clone repo
+      - if: ${{ !env.ACT }}
+        name: Clone repo
         uses: actions/checkout@v3
 
-      - name: Render terraform docs and push changes back to PR
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            tf:
+              - '**/*.tf'
+              - '**/README.md'
+      - if: steps.changes.outputs.tf == 'true'
+        name: Render terraform docs and push changes back to PR
         uses: terraform-docs/gh-actions@main
         with:
           config-file: .terraform-docs.yaml

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -32,3 +32,4 @@ jobs:
         with:
           config-file: .terraform-docs.yaml
           git-push: "true"
+          working-dir: .

--- a/.terraform-docs.yaml
+++ b/.terraform-docs.yaml
@@ -1,0 +1,17 @@
+formatter: "markdown"
+
+recursive:
+  enabled: true
+  path: modules
+
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+sort:
+  enabled: true
+  by: name

--- a/.terraform-docs.yaml
+++ b/.terraform-docs.yaml
@@ -14,4 +14,4 @@ output:
 
 sort:
   enabled: true
-  by: name
+  by: required

--- a/README.md
+++ b/README.md
@@ -74,3 +74,29 @@ The following modules are currently not working for Swiss OTC:
 2. [Set up a secure remote Terraform state](./tf_state_backend)
    . Copy the backend output of that module to your `settings.tf` file
 3. Use https://github.com/iits-consulting/otc-infrastructure-charts-template if you want to use ArgoCD (GitOps)
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -74,29 +74,3 @@ The following modules are currently not working for Swiss OTC:
 2. [Set up a secure remote Terraform state](./tf_state_backend)
    . Copy the backend output of that module to your `settings.tf` file
 3. Use https://github.com/iits-consulting/otc-infrastructure-charts-template if you want to use ArgoCD (GitOps)
-
-<!-- BEGIN_TF_DOCS -->
-## Requirements
-
-No requirements.
-
-## Providers
-
-No providers.
-
-## Modules
-
-No modules.
-
-## Resources
-
-No resources.
-
-## Inputs
-
-No inputs.
-
-## Outputs
-
-No outputs.
-<!-- END_TF_DOCS -->

--- a/modules/acme/README.md
+++ b/modules/acme/README.md
@@ -19,3 +19,59 @@ Notes:
 - The DNS admin user is designed to rotate its password every 30 days to comply with password policies.
 - This module is designed to work with OTC DNS and will require a valid public DNS zone configured.
 - Due to a bug in letsencrypt go library, it is possible to get an error 400 from OTC when attempting DNS challenge. If it happens, simply retry applying.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_acme"></a> [acme](#provider\_acme) | n/a |
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_time"></a> [time](#provider\_time) | n/a |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [acme_certificate.certificate](https://registry.terraform.io/providers/vancluever/acme/latest/docs/resources/certificate) | resource |
+| [acme_registration.registration](https://registry.terraform.io/providers/vancluever/acme/latest/docs/resources/registration) | resource |
+| [opentelekomcloud_identity_group_membership_v3.dns_admin_membership](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/identity_group_membership_v3) | resource |
+| [opentelekomcloud_identity_group_v3.dns_admin_group](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/identity_group_v3) | resource |
+| [opentelekomcloud_identity_role_assignment_v3.dns_admin_to_dns_admin_group](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/identity_role_assignment_v3) | resource |
+| [opentelekomcloud_identity_user_v3.dns_admin](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/identity_user_v3) | resource |
+| [random_password.dns_admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [time_rotating.password_rotation](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/rotating) | resource |
+| [time_sleep.cert_delay](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [tls_private_key.registration](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [opentelekomcloud_identity_project_v3.project](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/identity_project_v3) | data source |
+| [opentelekomcloud_identity_role_v3.dns_admin_role](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/identity_role_v3) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cert_key_type"></a> [cert\_key\_type](#input\_cert\_key\_type) | The key type for the certificate's private key. Can be one of: P256 and P384 (for ECDSA keys of respective length) or 2048, 4096, and 8192 (for RSA keys of respective length). (default: P256) | `string` | `"P256"` | no |
+| <a name="input_cert_min_days_remaining"></a> [cert\_min\_days\_remaining](#input\_cert\_min\_days\_remaining) | Number of days remaining when terraform apply will automatically renew the certificate. (default: 30) | `number` | `30` | no |
+| <a name="input_cert_registration_email"></a> [cert\_registration\_email](#input\_cert\_registration\_email) | E-mail associated with certificate generation. | `string` | n/a | yes |
+| <a name="input_cert_registration_key_type"></a> [cert\_registration\_key\_type](#input\_cert\_registration\_key\_type) | The key type for the ACME registration private key. Can be one of: P256 and P384 (for ECDSA keys of respective length) or 2048, 4096, and 8192 (for RSA keys of respective length). (default: P256) | `string` | `"P256"` | no |
+| <a name="input_dns_admin_name"></a> [dns\_admin\_name](#input\_dns\_admin\_name) | Name of the automated DNS admin user. (default: terraform\_acme\_dns\_manager) | `string` | `"terraform_acme_dns_manager"` | no |
+| <a name="input_domains"></a> [domains](#input\_domains) | Map of common names to alternative names to create ACME certificates. Module supports wildcard certificates, common name does not need to be included in alternative names. | `map(list(string))` | n/a | yes |
+| <a name="input_otc_domain_name"></a> [otc\_domain\_name](#input\_otc\_domain\_name) | OTC domain name for the cloud subscription. Usually in form OTC-EU-DE-000000000010XXXXXXXX | `string` | n/a | yes |
+| <a name="input_otc_project_name"></a> [otc\_project\_name](#input\_otc\_project\_name) | OTC project name in format "eu-de\_<project\_name>" or "eu-nl\_<project\_name>". The project must have the dns zone(s) created. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_certificate"></a> [certificate](#output\_certificate) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/acme/README.md
+++ b/modules/acme/README.md
@@ -60,14 +60,14 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cert_key_type"></a> [cert\_key\_type](#input\_cert\_key\_type) | The key type for the certificate's private key. Can be one of: P256 and P384 (for ECDSA keys of respective length) or 2048, 4096, and 8192 (for RSA keys of respective length). (default: P256) | `string` | `"P256"` | no |
-| <a name="input_cert_min_days_remaining"></a> [cert\_min\_days\_remaining](#input\_cert\_min\_days\_remaining) | Number of days remaining when terraform apply will automatically renew the certificate. (default: 30) | `number` | `30` | no |
 | <a name="input_cert_registration_email"></a> [cert\_registration\_email](#input\_cert\_registration\_email) | E-mail associated with certificate generation. | `string` | n/a | yes |
-| <a name="input_cert_registration_key_type"></a> [cert\_registration\_key\_type](#input\_cert\_registration\_key\_type) | The key type for the ACME registration private key. Can be one of: P256 and P384 (for ECDSA keys of respective length) or 2048, 4096, and 8192 (for RSA keys of respective length). (default: P256) | `string` | `"P256"` | no |
-| <a name="input_dns_admin_name"></a> [dns\_admin\_name](#input\_dns\_admin\_name) | Name of the automated DNS admin user. (default: terraform\_acme\_dns\_manager) | `string` | `"terraform_acme_dns_manager"` | no |
 | <a name="input_domains"></a> [domains](#input\_domains) | Map of common names to alternative names to create ACME certificates. Module supports wildcard certificates, common name does not need to be included in alternative names. | `map(list(string))` | n/a | yes |
 | <a name="input_otc_domain_name"></a> [otc\_domain\_name](#input\_otc\_domain\_name) | OTC domain name for the cloud subscription. Usually in form OTC-EU-DE-000000000010XXXXXXXX | `string` | n/a | yes |
 | <a name="input_otc_project_name"></a> [otc\_project\_name](#input\_otc\_project\_name) | OTC project name in format "eu-de\_<project\_name>" or "eu-nl\_<project\_name>". The project must have the dns zone(s) created. | `string` | n/a | yes |
+| <a name="input_cert_key_type"></a> [cert\_key\_type](#input\_cert\_key\_type) | The key type for the certificate's private key. Can be one of: P256 and P384 (for ECDSA keys of respective length) or 2048, 4096, and 8192 (for RSA keys of respective length). (default: P256) | `string` | `"P256"` | no |
+| <a name="input_cert_min_days_remaining"></a> [cert\_min\_days\_remaining](#input\_cert\_min\_days\_remaining) | Number of days remaining when terraform apply will automatically renew the certificate. (default: 30) | `number` | `30` | no |
+| <a name="input_cert_registration_key_type"></a> [cert\_registration\_key\_type](#input\_cert\_registration\_key\_type) | The key type for the ACME registration private key. Can be one of: P256 and P384 (for ECDSA keys of respective length) or 2048, 4096, and 8192 (for RSA keys of respective length). (default: P256) | `string` | `"P256"` | no |
+| <a name="input_dns_admin_name"></a> [dns\_admin\_name](#input\_dns\_admin\_name) | Name of the automated DNS admin user. (default: terraform\_acme\_dns\_manager) | `string` | `"terraform_acme_dns_manager"` | no |
 
 ## Outputs
 

--- a/modules/cce/README.md
+++ b/modules/cce/README.md
@@ -141,3 +141,102 @@ Scaling down again...
 
 yields removed nodes in the Web Console.
 ![](img/scaledown_event.jpg)
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_opentelekomcloud"></a> [opentelekomcloud](#requirement\_opentelekomcloud) | >=1.31.7 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_errorcheck"></a> [errorcheck](#provider\_errorcheck) | n/a |
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | >=1.31.7 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [errorcheck_is_valid.cluster_authenticating_proxy_config](https://registry.terraform.io/providers/iits-consulting/errorcheck/latest/docs/resources/is_valid) | resource |
+| [errorcheck_is_valid.container_network_type](https://registry.terraform.io/providers/iits-consulting/errorcheck/latest/docs/resources/is_valid) | resource |
+| [errorcheck_is_valid.node_availability_zones](https://registry.terraform.io/providers/iits-consulting/errorcheck/latest/docs/resources/is_valid) | resource |
+| [opentelekomcloud_cce_addon_v3.autoscaler](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/cce_addon_v3) | resource |
+| [opentelekomcloud_cce_addon_v3.metrics](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/cce_addon_v3) | resource |
+| [opentelekomcloud_cce_cluster_v3.cluster](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/cce_cluster_v3) | resource |
+| [opentelekomcloud_cce_node_pool_v3.cluster_node_pool](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/cce_node_pool_v3) | resource |
+| [opentelekomcloud_compute_keypair_v2.cluster_keypair](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/compute_keypair_v2) | resource |
+| [opentelekomcloud_kms_key_v1.node_storage_encryption_key](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/kms_key_v1) | resource |
+| [opentelekomcloud_vpc_eip_v1.cce_eip](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/vpc_eip_v1) | resource |
+| [random_id.cluster_keypair_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_id.id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [tls_private_key.cluster_keypair](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [opentelekomcloud_cce_addon_template_v3.autoscaler](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/cce_addon_template_v3) | data source |
+| [opentelekomcloud_cce_addon_template_v3.metrics](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/cce_addon_template_v3) | data source |
+| [opentelekomcloud_identity_project_v3.current](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/identity_project_v3) | data source |
+| [opentelekomcloud_kms_key_v1.node_storage_encryption_existing_key](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/kms_key_v1) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_autoscaler_node_max"></a> [autoscaler\_node\_max](#input\_autoscaler\_node\_max) | Maximum limit of servers to create (default: 10) | `number` | `10` | no |
+| <a name="input_autoscaler_node_min"></a> [autoscaler\_node\_min](#input\_autoscaler\_node\_min) | Lower bound of servers to always keep (default: <node\_count>) | `number` | `null` | no |
+| <a name="input_autoscaler_version"></a> [autoscaler\_version](#input\_autoscaler\_version) | Version of the Autoscaler Addon Template (default: 1.25.7) | `string` | `"1.25.7"` | no |
+| <a name="input_cluster_authenticating_proxy_ca"></a> [cluster\_authenticating\_proxy\_ca](#input\_cluster\_authenticating\_proxy\_ca) | X509 CA certificate configured in authenticating\_proxy mode. The maximum size of the certificate is 1 MB. | `string` | `null` | no |
+| <a name="input_cluster_authenticating_proxy_cert"></a> [cluster\_authenticating\_proxy\_cert](#input\_cluster\_authenticating\_proxy\_cert) | Client certificate issued by the X509 CA certificate configured in authenticating\_proxy mode. | `string` | `null` | no |
+| <a name="input_cluster_authenticating_proxy_private_key"></a> [cluster\_authenticating\_proxy\_private\_key](#input\_cluster\_authenticating\_proxy\_private\_key) | Private key of the client certificate issued by the X509 CA certificate configured in authenticating\_proxy mode. | `string` | `null` | no |
+| <a name="input_cluster_authentication_mode"></a> [cluster\_authentication\_mode](#input\_cluster\_authentication\_mode) | Authentication mode of the Cluster. Either rbac or authenticating\_proxy (default: rbac) | `string` | `"rbac"` | no |
+| <a name="input_cluster_container_cidr"></a> [cluster\_container\_cidr](#input\_cluster\_container\_cidr) | Kubernetes pod network CIDR range (default: 172.16.0.0/16) | `string` | `"172.16.0.0/16"` | no |
+| <a name="input_cluster_container_network_type"></a> [cluster\_container\_network\_type](#input\_cluster\_container\_network\_type) | Container network type: vpc-router or overlay\_l2 for VirtualMachine Clusters; underlay\_ipvlan for BareMetal Clusters | `string` | `""` | no |
+| <a name="input_cluster_enable_scaling"></a> [cluster\_enable\_scaling](#input\_cluster\_enable\_scaling) | Enable autoscaling of the cluster (default: false) | `bool` | `false` | no |
+| <a name="input_cluster_high_availability"></a> [cluster\_high\_availability](#input\_cluster\_high\_availability) | Create the cluster in highly available mode (default: false) | `bool` | `false` | no |
+| <a name="input_cluster_install_icagent"></a> [cluster\_install\_icagent](#input\_cluster\_install\_icagent) | install icagent for logging and metrics (default: false) | `bool` | `false` | no |
+| <a name="input_cluster_public_access"></a> [cluster\_public\_access](#input\_cluster\_public\_access) | Bind a public IP to the CLuster to make it public available (default: true) | `bool` | `true` | no |
+| <a name="input_cluster_service_cidr"></a> [cluster\_service\_cidr](#input\_cluster\_service\_cidr) | Kubernetes service network CIDR range (default: 10.247.0.0/16) | `string` | `"10.247.0.0/16"` | no |
+| <a name="input_cluster_size"></a> [cluster\_size](#input\_cluster\_size) | Size of the cluster: small, medium, large (default: small) | `string` | `"small"` | no |
+| <a name="input_cluster_subnet_id"></a> [cluster\_subnet\_id](#input\_cluster\_subnet\_id) | Subnet network id where the cluster will be created in | `string` | n/a | yes |
+| <a name="input_cluster_type"></a> [cluster\_type](#input\_cluster\_type) | Cluster type: VirtualMachine or BareMetal (default: VirtualMachine) | `string` | `"VirtualMachine"` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | CCE cluster version. | `string` | `"v1.25"` | no |
+| <a name="input_cluster_vpc_id"></a> [cluster\_vpc\_id](#input\_cluster\_vpc\_id) | VPC id where the cluster will be created in | `string` | n/a | yes |
+| <a name="input_metrics_server_version"></a> [metrics\_server\_version](#input\_metrics\_server\_version) | Version of the Metrics Server Addon Template (default: 1.3.2) | `string` | `"1.3.2"` | no |
+| <a name="input_name"></a> [name](#input\_name) | CCE cluster name | `string` | n/a | yes |
+| <a name="input_node_availability_zones"></a> [node\_availability\_zones](#input\_node\_availability\_zones) | Availability zones for the node pools. Providing multiple availability zones creates one node pool in each zone. | `set(string)` | n/a | yes |
+| <a name="input_node_container_runtime"></a> [node\_container\_runtime](#input\_node\_container\_runtime) | The container runtime to use. Must be set to either containerd or docker. (default: containerd) | `string` | `"containerd"` | no |
+| <a name="input_node_count"></a> [node\_count](#input\_node\_count) | Number of nodes to create | `number` | n/a | yes |
+| <a name="input_node_flavor"></a> [node\_flavor](#input\_node\_flavor) | Node specifications in otc flavor format | `string` | n/a | yes |
+| <a name="input_node_os"></a> [node\_os](#input\_node\_os) | Operating system of worker nodes: EulerOS 2.5 or CentOS 7.7 (default: EulerOS 2.9) | `string` | `"EulerOS 2.9"` | no |
+| <a name="input_node_postinstall"></a> [node\_postinstall](#input\_node\_postinstall) | Post install script for the cluster ECS node pool. | `string` | `""` | no |
+| <a name="input_node_storage_encryption_enabled"></a> [node\_storage\_encryption\_enabled](#input\_node\_storage\_encryption\_enabled) | Enable OTC KMS volume encryption for the node pool volumes. (default: false) | `bool` | `false` | no |
+| <a name="input_node_storage_encryption_kms_key_name"></a> [node\_storage\_encryption\_kms\_key\_name](#input\_node\_storage\_encryption\_kms\_key\_name) | If KMS volume encryption is enabled, specify a name of an existing kms key. Setting this disables the creation of a new kms key. (default: null) | `string` | `null` | no |
+| <a name="input_node_storage_size"></a> [node\_storage\_size](#input\_node\_storage\_size) | Size of the node system disk in GB (default: 100) | `number` | `100` | no |
+| <a name="input_node_storage_type"></a> [node\_storage\_type](#input\_node\_storage\_type) | Type of node storage SATA, SAS or SSD (default: SATA) | `string` | `"SATA"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Common tag set for CCE resources | `map(any)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cluster_credentials"></a> [cluster\_credentials](#output\_cluster\_credentials) | n/a |
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | n/a |
+| <a name="output_cluster_lb_public_ip"></a> [cluster\_lb\_public\_ip](#output\_cluster\_lb\_public\_ip) | This has nothing to do with lb (loadbalancer) it is kept for backwards compatibility |
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | n/a |
+| <a name="output_cluster_private_ip"></a> [cluster\_private\_ip](#output\_cluster\_private\_ip) | n/a |
+| <a name="output_cluster_public_ip"></a> [cluster\_public\_ip](#output\_cluster\_public\_ip) | n/a |
+| <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | n/a |
+| <a name="output_kubeconfig_json"></a> [kubeconfig\_json](#output\_kubeconfig\_json) | n/a |
+| <a name="output_kubeconfig_yaml"></a> [kubeconfig\_yaml](#output\_kubeconfig\_yaml) | n/a |
+| <a name="output_node_pool_ids"></a> [node\_pool\_ids](#output\_node\_pool\_ids) | n/a |
+| <a name="output_node_pool_keypair_name"></a> [node\_pool\_keypair\_name](#output\_node\_pool\_keypair\_name) | n/a |
+| <a name="output_node_pool_keypair_private_key"></a> [node\_pool\_keypair\_private\_key](#output\_node\_pool\_keypair\_private\_key) | n/a |
+| <a name="output_node_pool_keypair_public_key"></a> [node\_pool\_keypair\_public\_key](#output\_node\_pool\_keypair\_public\_key) | n/a |
+| <a name="output_node_sg_id"></a> [node\_sg\_id](#output\_node\_sg\_id) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/cce/README.md
+++ b/modules/cce/README.md
@@ -196,7 +196,7 @@ No modules.
 | <a name="input_node_flavor"></a> [node\_flavor](#input\_node\_flavor) | Node specifications in otc flavor format | `string` | n/a | yes |
 | <a name="input_autoscaler_node_max"></a> [autoscaler\_node\_max](#input\_autoscaler\_node\_max) | Maximum limit of servers to create (default: 10) | `number` | `10` | no |
 | <a name="input_autoscaler_node_min"></a> [autoscaler\_node\_min](#input\_autoscaler\_node\_min) | Lower bound of servers to always keep (default: <node\_count>) | `number` | `null` | no |
-| <a name="input_autoscaler_version"></a> [autoscaler\_version](#input\_autoscaler\_version) | Version of the Autoscaler Addon Template (default: 1.25.7) | `string` | `"1.25.7"` | no |
+| <a name="input_autoscaler_version"></a> [autoscaler\_version](#input\_autoscaler\_version) | Version of the Autoscaler Addon Template (default: 1.25.7) | `string` | `"1.25.21"` | no |
 | <a name="input_cluster_authenticating_proxy_ca"></a> [cluster\_authenticating\_proxy\_ca](#input\_cluster\_authenticating\_proxy\_ca) | X509 CA certificate configured in authenticating\_proxy mode. The maximum size of the certificate is 1 MB. | `string` | `null` | no |
 | <a name="input_cluster_authenticating_proxy_cert"></a> [cluster\_authenticating\_proxy\_cert](#input\_cluster\_authenticating\_proxy\_cert) | Client certificate issued by the X509 CA certificate configured in authenticating\_proxy mode. | `string` | `null` | no |
 | <a name="input_cluster_authenticating_proxy_private_key"></a> [cluster\_authenticating\_proxy\_private\_key](#input\_cluster\_authenticating\_proxy\_private\_key) | Private key of the client certificate issued by the X509 CA certificate configured in authenticating\_proxy mode. | `string` | `null` | no |
@@ -211,7 +211,7 @@ No modules.
 | <a name="input_cluster_size"></a> [cluster\_size](#input\_cluster\_size) | Size of the cluster: small, medium, large (default: small) | `string` | `"small"` | no |
 | <a name="input_cluster_type"></a> [cluster\_type](#input\_cluster\_type) | Cluster type: VirtualMachine or BareMetal (default: VirtualMachine) | `string` | `"VirtualMachine"` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | CCE cluster version. | `string` | `"v1.25"` | no |
-| <a name="input_metrics_server_version"></a> [metrics\_server\_version](#input\_metrics\_server\_version) | Version of the Metrics Server Addon Template (default: 1.3.2) | `string` | `"1.3.2"` | no |
+| <a name="input_metrics_server_version"></a> [metrics\_server\_version](#input\_metrics\_server\_version) | Version of the Metrics Server Addon Template (default: 1.3.2) | `string` | `"1.3.6"` | no |
 | <a name="input_node_container_runtime"></a> [node\_container\_runtime](#input\_node\_container\_runtime) | The container runtime to use. Must be set to either containerd or docker. (default: containerd) | `string` | `"containerd"` | no |
 | <a name="input_node_os"></a> [node\_os](#input\_node\_os) | Operating system of worker nodes: EulerOS 2.5 or CentOS 7.7 (default: EulerOS 2.9) | `string` | `"EulerOS 2.9"` | no |
 | <a name="input_node_postinstall"></a> [node\_postinstall](#input\_node\_postinstall) | Post install script for the cluster ECS node pool. | `string` | `""` | no |

--- a/modules/cce/README.md
+++ b/modules/cce/README.md
@@ -188,6 +188,12 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cluster_subnet_id"></a> [cluster\_subnet\_id](#input\_cluster\_subnet\_id) | Subnet network id where the cluster will be created in | `string` | n/a | yes |
+| <a name="input_cluster_vpc_id"></a> [cluster\_vpc\_id](#input\_cluster\_vpc\_id) | VPC id where the cluster will be created in | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | CCE cluster name | `string` | n/a | yes |
+| <a name="input_node_availability_zones"></a> [node\_availability\_zones](#input\_node\_availability\_zones) | Availability zones for the node pools. Providing multiple availability zones creates one node pool in each zone. | `set(string)` | n/a | yes |
+| <a name="input_node_count"></a> [node\_count](#input\_node\_count) | Number of nodes to create | `number` | n/a | yes |
+| <a name="input_node_flavor"></a> [node\_flavor](#input\_node\_flavor) | Node specifications in otc flavor format | `string` | n/a | yes |
 | <a name="input_autoscaler_node_max"></a> [autoscaler\_node\_max](#input\_autoscaler\_node\_max) | Maximum limit of servers to create (default: 10) | `number` | `10` | no |
 | <a name="input_autoscaler_node_min"></a> [autoscaler\_node\_min](#input\_autoscaler\_node\_min) | Lower bound of servers to always keep (default: <node\_count>) | `number` | `null` | no |
 | <a name="input_autoscaler_version"></a> [autoscaler\_version](#input\_autoscaler\_version) | Version of the Autoscaler Addon Template (default: 1.25.7) | `string` | `"1.25.7"` | no |
@@ -203,16 +209,10 @@ No modules.
 | <a name="input_cluster_public_access"></a> [cluster\_public\_access](#input\_cluster\_public\_access) | Bind a public IP to the CLuster to make it public available (default: true) | `bool` | `true` | no |
 | <a name="input_cluster_service_cidr"></a> [cluster\_service\_cidr](#input\_cluster\_service\_cidr) | Kubernetes service network CIDR range (default: 10.247.0.0/16) | `string` | `"10.247.0.0/16"` | no |
 | <a name="input_cluster_size"></a> [cluster\_size](#input\_cluster\_size) | Size of the cluster: small, medium, large (default: small) | `string` | `"small"` | no |
-| <a name="input_cluster_subnet_id"></a> [cluster\_subnet\_id](#input\_cluster\_subnet\_id) | Subnet network id where the cluster will be created in | `string` | n/a | yes |
 | <a name="input_cluster_type"></a> [cluster\_type](#input\_cluster\_type) | Cluster type: VirtualMachine or BareMetal (default: VirtualMachine) | `string` | `"VirtualMachine"` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | CCE cluster version. | `string` | `"v1.25"` | no |
-| <a name="input_cluster_vpc_id"></a> [cluster\_vpc\_id](#input\_cluster\_vpc\_id) | VPC id where the cluster will be created in | `string` | n/a | yes |
 | <a name="input_metrics_server_version"></a> [metrics\_server\_version](#input\_metrics\_server\_version) | Version of the Metrics Server Addon Template (default: 1.3.2) | `string` | `"1.3.2"` | no |
-| <a name="input_name"></a> [name](#input\_name) | CCE cluster name | `string` | n/a | yes |
-| <a name="input_node_availability_zones"></a> [node\_availability\_zones](#input\_node\_availability\_zones) | Availability zones for the node pools. Providing multiple availability zones creates one node pool in each zone. | `set(string)` | n/a | yes |
 | <a name="input_node_container_runtime"></a> [node\_container\_runtime](#input\_node\_container\_runtime) | The container runtime to use. Must be set to either containerd or docker. (default: containerd) | `string` | `"containerd"` | no |
-| <a name="input_node_count"></a> [node\_count](#input\_node\_count) | Number of nodes to create | `number` | n/a | yes |
-| <a name="input_node_flavor"></a> [node\_flavor](#input\_node\_flavor) | Node specifications in otc flavor format | `string` | n/a | yes |
 | <a name="input_node_os"></a> [node\_os](#input\_node\_os) | Operating system of worker nodes: EulerOS 2.5 or CentOS 7.7 (default: EulerOS 2.9) | `string` | `"EulerOS 2.9"` | no |
 | <a name="input_node_postinstall"></a> [node\_postinstall](#input\_node\_postinstall) | Post install script for the cluster ECS node pool. | `string` | `""` | no |
 | <a name="input_node_storage_encryption_enabled"></a> [node\_storage\_encryption\_enabled](#input\_node\_storage\_encryption\_enabled) | Enable OTC KMS volume encryption for the node pool volumes. (default: false) | `bool` | `false` | no |

--- a/modules/cce_auto_creation/README.md
+++ b/modules/cce_auto_creation/README.md
@@ -2,3 +2,37 @@
 
 This module prepares the management of a CCE cluster in the OTC. Normally, a manual acceptance is needed in the OTC
 console to enable the CCE features. This module emulates the acceptance click by creating an agency. 
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_opentelekomcloud"></a> [opentelekomcloud](#requirement\_opentelekomcloud) | >=1.31.5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | >=1.31.5 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [opentelekomcloud_identity_agency_v3.enable_cce_auto_creation](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/identity_agency_v3) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_project"></a> [project](#input\_project) | n/a | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/cts/README.md
+++ b/modules/cts/README.md
@@ -17,6 +17,24 @@ module "cts" {
 }
 ```
 
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_opentelekomcloud"></a> [opentelekomcloud](#requirement\_opentelekomcloud) | >=1.32.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | >=1.32.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
 ## Resources
 
 | Name | Type |
@@ -39,3 +57,5 @@ module "cts" {
 ## Outputs
 
 No outputs.
+<!-- END_TF_DOCS -->
+

--- a/modules/evs/README.md
+++ b/modules/evs/README.md
@@ -1,0 +1,40 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [opentelekomcloud_evs_volume_v3.evs_volumes](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/evs_volume_v3) | resource |
+| [opentelekomcloud_kms_key_v1.volume_kms_key](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/kms_key_v1) | resource |
+| [random_id.volume_kms_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_kms_key_prefix"></a> [kms\_key\_prefix](#input\_kms\_key\_prefix) | n/a | `string` | n/a | yes |
+| <a name="input_volume_names"></a> [volume\_names](#input\_volume\_names) | n/a | `list(string)` | n/a | yes |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | n/a | `list` | <pre>[<br>  "eu-de-01"<br>]</pre> | no |
+| <a name="input_spec"></a> [spec](#input\_spec) | n/a | `map` | <pre>{<br>  "device_type": "SCSI",<br>  "size": 20,<br>  "volume_type": "SSD"<br>}</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Common tag set for project resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_volumes"></a> [volumes](#output\_volumes) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/jumphost/README.md
+++ b/modules/jumphost/README.md
@@ -50,3 +50,74 @@ or
 terraform taint module.<module_name>.opentelekomcloud_blockstorage_volume_v2.jumphost_boot_volume
 terraform apply
 ```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_opentelekomcloud"></a> [opentelekomcloud](#requirement\_opentelekomcloud) | >=1.31.5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_errorcheck"></a> [errorcheck](#provider\_errorcheck) | n/a |
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | >=1.31.5 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [errorcheck_is_valid.availability_zone](https://registry.terraform.io/providers/iits-consulting/errorcheck/latest/docs/resources/is_valid) | resource |
+| [opentelekomcloud_blockstorage_volume_v2.jumphost_boot_volume](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/blockstorage_volume_v2) | resource |
+| [opentelekomcloud_compute_instance_v2.jumphost_node](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/compute_instance_v2) | resource |
+| [opentelekomcloud_kms_key_v1.jumphost_storage_encryption_key](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/kms_key_v1) | resource |
+| [opentelekomcloud_networking_floatingip_associate_v2.jumphost_eip_association](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/networking_floatingip_associate_v2) | resource |
+| [opentelekomcloud_networking_secgroup_rule_v2.jumphost_secgroup_rule_internet](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/networking_secgroup_rule_v2) | resource |
+| [opentelekomcloud_networking_secgroup_rule_v2.jumphost_secgroup_rule_ssh](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/networking_secgroup_rule_v2) | resource |
+| [opentelekomcloud_networking_secgroup_rule_v2.jumphost_sg_group_in](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/networking_secgroup_rule_v2) | resource |
+| [opentelekomcloud_networking_secgroup_rule_v2.jumphost_sg_group_out](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/networking_secgroup_rule_v2) | resource |
+| [opentelekomcloud_networking_secgroup_v2.jumphost_secgroup](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/networking_secgroup_v2) | resource |
+| [opentelekomcloud_vpc_eip_v1.jumphost_eip](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/vpc_eip_v1) | resource |
+| [random_id.jumphost_storage_encryption_key](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [tls_private_key.host_key_ecdsa](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [tls_private_key.host_key_ed25519](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [tls_private_key.host_key_rsa](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [opentelekomcloud_identity_project_v3.current](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/identity_project_v3) | data source |
+| [opentelekomcloud_kms_key_v1.jumphost_storage_existing_encryption_key](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/kms_key_v1) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_security_groups"></a> [additional\_security\_groups](#input\_additional\_security\_groups) | Additional security group names for Jumphost. | `list(string)` | `[]` | no |
+| <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | Availability zone for the jumphost node. | `string` | `""` | no |
+| <a name="input_cloud_init"></a> [cloud\_init](#input\_cloud\_init) | Custom Cloud-init configuration. Cloud-init cloud config format is expected. Only *.yml and *.yaml files will be read. | `string` | `""` | no |
+| <a name="input_node_bandwidth_size"></a> [node\_bandwidth\_size](#input\_node\_bandwidth\_size) | Jumphost node external IP bandwidth size in Mbps. (default: 10) | `number` | `10` | no |
+| <a name="input_node_flavor"></a> [node\_flavor](#input\_node\_flavor) | Jumphost node specifications in otc flavor format. (default: s3.medium.2 (3rd generation 1 Core 2GB RAM)) | `string` | `"s3.medium.2"` | no |
+| <a name="input_node_image_id"></a> [node\_image\_id](#input\_node\_image\_id) | Jumphost node image name. Image must exist within the same project as the jumphost node. (default: 9f92079d-9d1b-4832-90c1-a3b4a1c00b9b (Standard\_Ubuntu\_20.04\_latest)) | `string` | `"9f92079d-9d1b-4832-90c1-a3b4a1c00b9b"` | no |
+| <a name="input_node_name"></a> [node\_name](#input\_node\_name) | Jumphost node name. | `any` | n/a | yes |
+| <a name="input_node_storage_encryption_enabled"></a> [node\_storage\_encryption\_enabled](#input\_node\_storage\_encryption\_enabled) | Jumphost node system disk storage KMS encryption toggle. | `bool` | `false` | no |
+| <a name="input_node_storage_encryption_key_name"></a> [node\_storage\_encryption\_key\_name](#input\_node\_storage\_encryption\_key\_name) | If jumphost system disk KMS encryption is enabled, use this KMS key name instead of creating a new one. | `string` | `null` | no |
+| <a name="input_node_storage_size"></a> [node\_storage\_size](#input\_node\_storage\_size) | Jumphost node system disk storage size in GB. (default: 20) | `number` | `20` | no |
+| <a name="input_node_storage_type"></a> [node\_storage\_type](#input\_node\_storage\_type) | Jumphost node system disk storage type. Must be one of "SATA", "SAS", or "SSD". (default: SSD) | `string` | `"SSD"` | no |
+| <a name="input_preserve_host_keys"></a> [preserve\_host\_keys](#input\_preserve\_host\_keys) | Enable to generate host keys via terraform and preserve them in the state to keep node identity consistent. (default: true) | `bool` | `true` | no |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Jumphost subnet id for node network configuration | `any` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Jumphost tag set. | `map(string)` | `{}` | no |
+| <a name="input_trusted_ssh_origins"></a> [trusted\_ssh\_origins](#input\_trusted\_ssh\_origins) | IP addresses and/or ranges allowed to SSH into the jumphost. (default: ["0.0.0.0/0"] (Allow access from all IP addresses.)) | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_jumphost_address"></a> [jumphost\_address](#output\_jumphost\_address) | n/a |
+| <a name="output_jumphost_private_address"></a> [jumphost\_private\_address](#output\_jumphost\_private\_address) | n/a |
+| <a name="output_jumphost_sg_id"></a> [jumphost\_sg\_id](#output\_jumphost\_sg\_id) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/jumphost/README.md
+++ b/modules/jumphost/README.md
@@ -97,19 +97,19 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_node_name"></a> [node\_name](#input\_node\_name) | Jumphost node name. | `any` | n/a | yes |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Jumphost subnet id for node network configuration | `any` | n/a | yes |
 | <a name="input_additional_security_groups"></a> [additional\_security\_groups](#input\_additional\_security\_groups) | Additional security group names for Jumphost. | `list(string)` | `[]` | no |
 | <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | Availability zone for the jumphost node. | `string` | `""` | no |
 | <a name="input_cloud_init"></a> [cloud\_init](#input\_cloud\_init) | Custom Cloud-init configuration. Cloud-init cloud config format is expected. Only *.yml and *.yaml files will be read. | `string` | `""` | no |
 | <a name="input_node_bandwidth_size"></a> [node\_bandwidth\_size](#input\_node\_bandwidth\_size) | Jumphost node external IP bandwidth size in Mbps. (default: 10) | `number` | `10` | no |
 | <a name="input_node_flavor"></a> [node\_flavor](#input\_node\_flavor) | Jumphost node specifications in otc flavor format. (default: s3.medium.2 (3rd generation 1 Core 2GB RAM)) | `string` | `"s3.medium.2"` | no |
 | <a name="input_node_image_id"></a> [node\_image\_id](#input\_node\_image\_id) | Jumphost node image name. Image must exist within the same project as the jumphost node. (default: 9f92079d-9d1b-4832-90c1-a3b4a1c00b9b (Standard\_Ubuntu\_20.04\_latest)) | `string` | `"9f92079d-9d1b-4832-90c1-a3b4a1c00b9b"` | no |
-| <a name="input_node_name"></a> [node\_name](#input\_node\_name) | Jumphost node name. | `any` | n/a | yes |
 | <a name="input_node_storage_encryption_enabled"></a> [node\_storage\_encryption\_enabled](#input\_node\_storage\_encryption\_enabled) | Jumphost node system disk storage KMS encryption toggle. | `bool` | `false` | no |
 | <a name="input_node_storage_encryption_key_name"></a> [node\_storage\_encryption\_key\_name](#input\_node\_storage\_encryption\_key\_name) | If jumphost system disk KMS encryption is enabled, use this KMS key name instead of creating a new one. | `string` | `null` | no |
 | <a name="input_node_storage_size"></a> [node\_storage\_size](#input\_node\_storage\_size) | Jumphost node system disk storage size in GB. (default: 20) | `number` | `20` | no |
 | <a name="input_node_storage_type"></a> [node\_storage\_type](#input\_node\_storage\_type) | Jumphost node system disk storage type. Must be one of "SATA", "SAS", or "SSD". (default: SSD) | `string` | `"SSD"` | no |
 | <a name="input_preserve_host_keys"></a> [preserve\_host\_keys](#input\_preserve\_host\_keys) | Enable to generate host keys via terraform and preserve them in the state to keep node identity consistent. (default: true) | `bool` | `true` | no |
-| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Jumphost subnet id for node network configuration | `any` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Jumphost tag set. | `map(string)` | `{}` | no |
 | <a name="input_trusted_ssh_origins"></a> [trusted\_ssh\_origins](#input\_trusted\_ssh\_origins) | IP addresses and/or ranges allowed to SSH into the jumphost. (default: ["0.0.0.0/0"] (Allow access from all IP addresses.)) | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 

--- a/modules/keycloak_sso/README.md
+++ b/modules/keycloak_sso/README.md
@@ -50,3 +50,51 @@ Notes:
       otc_idp_rules        = file("./path/to/rules.json")
     }
 ```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_curl"></a> [curl](#provider\_curl) | n/a |
+| <a name="provider_errorcheck"></a> [errorcheck](#provider\_errorcheck) | n/a |
+| <a name="provider_keycloak"></a> [keycloak](#provider\_keycloak) | n/a |
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [errorcheck_is_valid.saml_descriptor_check](https://registry.terraform.io/providers/iits-consulting/errorcheck/latest/docs/resources/is_valid) | resource |
+| [keycloak_saml_client.otc](https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/saml_client) | resource |
+| [keycloak_saml_client_default_scopes.otc_default_scopes](https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/saml_client_default_scopes) | resource |
+| [opentelekomcloud_identity_mapping_v3.mapping](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/identity_mapping_v3) | resource |
+| [opentelekomcloud_identity_protocol_v3.saml](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/identity_protocol_v3) | resource |
+| [opentelekomcloud_identity_provider_v3.provider](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/identity_provider_v3) | resource |
+| [curl_curl.saml_descriptor](https://registry.terraform.io/providers/anschoewe/curl/latest/docs/data-sources/curl) | data source |
+| [opentelekomcloud_identity_project_v3.current](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/identity_project_v3) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_keycloak_domain_name"></a> [keycloak\_domain\_name](#input\_keycloak\_domain\_name) | The domain name for the. | `string` | n/a | yes |
+| <a name="input_keycloak_realm"></a> [keycloak\_realm](#input\_keycloak\_realm) | Keycloak realm to create SAML client. | `string` | n/a | yes |
+| <a name="input_otc_auth_endpoint"></a> [otc\_auth\_endpoint](#input\_otc\_auth\_endpoint) | Authentication endpoint for OTC. Default: https://auth.otc.t-systems.com | `string` | `"https://auth.otc.t-systems.com"` | no |
+| <a name="input_otc_idp_name"></a> [otc\_idp\_name](#input\_otc\_idp\_name) | Name of the identity provider resources in OTC. | `string` | n/a | yes |
+| <a name="input_otc_idp_rules"></a> [otc\_idp\_rules](#input\_otc\_idp\_rules) | n/a | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_otc_sso_url"></a> [otc\_sso\_url](#output\_otc\_sso\_url) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/keycloak_sso/README.md
+++ b/modules/keycloak_sso/README.md
@@ -88,9 +88,9 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_keycloak_domain_name"></a> [keycloak\_domain\_name](#input\_keycloak\_domain\_name) | The domain name for the. | `string` | n/a | yes |
 | <a name="input_keycloak_realm"></a> [keycloak\_realm](#input\_keycloak\_realm) | Keycloak realm to create SAML client. | `string` | n/a | yes |
-| <a name="input_otc_auth_endpoint"></a> [otc\_auth\_endpoint](#input\_otc\_auth\_endpoint) | Authentication endpoint for OTC. Default: https://auth.otc.t-systems.com | `string` | `"https://auth.otc.t-systems.com"` | no |
 | <a name="input_otc_idp_name"></a> [otc\_idp\_name](#input\_otc\_idp\_name) | Name of the identity provider resources in OTC. | `string` | n/a | yes |
 | <a name="input_otc_idp_rules"></a> [otc\_idp\_rules](#input\_otc\_idp\_rules) | n/a | `string` | n/a | yes |
+| <a name="input_otc_auth_endpoint"></a> [otc\_auth\_endpoint](#input\_otc\_auth\_endpoint) | Authentication endpoint for OTC. Default: https://auth.otc.t-systems.com | `string` | `"https://auth.otc.t-systems.com"` | no |
 
 ## Outputs
 

--- a/modules/loadbalancer/README.md
+++ b/modules/loadbalancer/README.md
@@ -20,3 +20,46 @@ module "loadbalancer" {
   subnet_id    = module.vpc.subnets["my-subnet"].subnet_id
 }
 ```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_opentelekomcloud"></a> [opentelekomcloud](#requirement\_opentelekomcloud) | >=1.31.5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | >=1.31.5 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [opentelekomcloud_lb_loadbalancer_v2.elb](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/lb_loadbalancer_v2) | resource |
+| [opentelekomcloud_vpc_eip_v1.ingress_eip](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/vpc_eip_v1) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bandwidth"></a> [bandwidth](#input\_bandwidth) | The bandwidth size. The value ranges from 1 to 1000 Mbit/s. | `number` | `300` | no |
+| <a name="input_context_name"></a> [context\_name](#input\_context\_name) | Short descriptive, readable label of the project you are working on. Is utilized as a part of resource names. | `string` | n/a | yes |
+| <a name="input_stage_name"></a> [stage\_name](#input\_stage\_name) | Utilized to distinguish separate, but mostly equal environments within the same project. Usually dev, test, qa, prod. | `string` | `"dev"` | no |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet where the elastic load balancer will be created. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_elb_id"></a> [elb\_id](#output\_elb\_id) | n/a |
+| <a name="output_elb_private_ip"></a> [elb\_private\_ip](#output\_elb\_private\_ip) | n/a |
+| <a name="output_elb_public_ip"></a> [elb\_public\_ip](#output\_elb\_public\_ip) | n/a |
+<!-- END_TF_DOCS -->
+

--- a/modules/loadbalancer/README.md
+++ b/modules/loadbalancer/README.md
@@ -49,10 +49,10 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_bandwidth"></a> [bandwidth](#input\_bandwidth) | The bandwidth size. The value ranges from 1 to 1000 Mbit/s. | `number` | `300` | no |
 | <a name="input_context_name"></a> [context\_name](#input\_context\_name) | Short descriptive, readable label of the project you are working on. Is utilized as a part of resource names. | `string` | n/a | yes |
-| <a name="input_stage_name"></a> [stage\_name](#input\_stage\_name) | Utilized to distinguish separate, but mostly equal environments within the same project. Usually dev, test, qa, prod. | `string` | `"dev"` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet where the elastic load balancer will be created. | `string` | n/a | yes |
+| <a name="input_bandwidth"></a> [bandwidth](#input\_bandwidth) | The bandwidth size. The value ranges from 1 to 1000 Mbit/s. | `number` | `300` | no |
+| <a name="input_stage_name"></a> [stage\_name](#input\_stage\_name) | Utilized to distinguish separate, but mostly equal environments within the same project. Usually dev, test, qa, prod. | `string` | `"dev"` | no |
 
 ## Outputs
 

--- a/modules/obs_restricted/README.md
+++ b/modules/obs_restricted/README.md
@@ -24,3 +24,59 @@ module "obs_restricted_eu_de" {
   }
 }
 ```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_opentelekomcloud"></a> [opentelekomcloud](#requirement\_opentelekomcloud) | >=1.31.5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | >=1.31.5 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [opentelekomcloud_identity_credential_v3.user_aksk](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/identity_credential_v3) | resource |
+| [opentelekomcloud_identity_group_membership_v3.user_to_obsgroup](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/identity_group_membership_v3) | resource |
+| [opentelekomcloud_identity_group_v3.obs_group](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/identity_group_v3) | resource |
+| [opentelekomcloud_identity_role_assignment_v3.kms_adm_to_obs_group](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/identity_role_assignment_v3) | resource |
+| [opentelekomcloud_identity_role_assignment_v3.obs_role_to_obs_group](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/identity_role_assignment_v3) | resource |
+| [opentelekomcloud_identity_user_v3.user](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/identity_user_v3) | resource |
+| [opentelekomcloud_kms_grant_v1.obs_user](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/kms_grant_v1) | resource |
+| [opentelekomcloud_kms_key_v1.bucket_kms_key](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/kms_key_v1) | resource |
+| [opentelekomcloud_obs_bucket.bucket](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/obs_bucket) | resource |
+| [opentelekomcloud_obs_bucket_policy.bucket_policy](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/obs_bucket_policy) | resource |
+| [random_id.bucket_kms_key_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [opentelekomcloud_identity_project_v3.obs_project](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/identity_project_v3) | data source |
+| [opentelekomcloud_identity_project_v3.toplevel](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/identity_project_v3) | data source |
+| [opentelekomcloud_identity_role_v3.kms_admin](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/identity_role_v3) | data source |
+| [opentelekomcloud_identity_role_v3.obs_read_role](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/identity_role_v3) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Bucket name. Make sure the provider for this module has tennant\_name=<region> set | `string` | n/a | yes |
+| <a name="input_enable_versioning"></a> [enable\_versioning](#input\_enable\_versioning) | Disable the versioning for the bucket. Default: true | `bool` | `true` | no |
+| <a name="input_region"></a> [region](#input\_region) | OTC region for the project: eu-de(default) or eu-nl | `string` | `"eu-de"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_bucket_access_key"></a> [bucket\_access\_key](#output\_bucket\_access\_key) | n/a |
+| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | n/a |
+| <a name="output_bucket_secret_key"></a> [bucket\_secret\_key](#output\_bucket\_secret\_key) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/obs_secrets_reader/README.md
+++ b/modules/obs_secrets_reader/README.md
@@ -28,3 +28,40 @@ module "stage_secrets_from_encrypted_s3_bucket" {
   ]
 }
 ```
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_errorcheck"></a> [errorcheck](#provider\_errorcheck) | n/a |
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [errorcheck_is_valid.check_secrets](https://registry.terraform.io/providers/iits-consulting/errorcheck/latest/docs/resources/is_valid) | resource |
+| [opentelekomcloud_s3_bucket_object.secrets](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/s3_bucket_object) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Bucket name to read secrets from. Make sure the provider for this module has access to both the bucket and the KMS resource in case of encryption. | `string` | n/a | yes |
+| <a name="input_bucket_object_key"></a> [bucket\_object\_key](#input\_bucket\_object\_key) | Path and name to the object within the bucket. | `string` | n/a | yes |
+| <a name="input_required_secrets"></a> [required\_secrets](#input\_required\_secrets) | Optional list of top level secret names (keys) to exist within the file. Any missing keys will result in an error. | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_secrets"></a> [secrets](#output\_secrets) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/obs_secrets_writer/README.md
+++ b/modules/obs_secrets_writer/README.md
@@ -34,3 +34,45 @@ module "stage_secrets_to_encrypted_s3_bucket" {
   }
 }
 ```
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_opentelekomcloud"></a> [opentelekomcloud](#requirement\_opentelekomcloud) | >=1.31.5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | >=1.31.5 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [opentelekomcloud_kms_key_v1.encrypted_secrets_key](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/kms_key_v1) | resource |
+| [opentelekomcloud_obs_bucket.secrets](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/obs_bucket) | resource |
+| [opentelekomcloud_obs_bucket_object.secrets](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/obs_bucket_object) | resource |
+| [random_id.id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Bucket name to read secrets from. Make sure the provider for this module has tennant\_name=<region> set | `string` | n/a | yes |
+| <a name="input_bucket_object_key"></a> [bucket\_object\_key](#input\_bucket\_object\_key) | n/a | `string` | n/a | yes |
+| <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | Create a new bucket or use an existing one. Default: true | `bool` | `true` | no |
+| <a name="input_enable_versioning"></a> [enable\_versioning](#input\_enable\_versioning) | Disable the versioning for the bucket. Default: true | `bool` | `true` | no |
+| <a name="input_secrets"></a> [secrets](#input\_secrets) | n/a | `map(any)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `null` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/obs_secrets_writer/README.md
+++ b/modules/obs_secrets_writer/README.md
@@ -67,9 +67,9 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Bucket name to read secrets from. Make sure the provider for this module has tennant\_name=<region> set | `string` | n/a | yes |
 | <a name="input_bucket_object_key"></a> [bucket\_object\_key](#input\_bucket\_object\_key) | n/a | `string` | n/a | yes |
+| <a name="input_secrets"></a> [secrets](#input\_secrets) | n/a | `map(any)` | n/a | yes |
 | <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | Create a new bucket or use an existing one. Default: true | `bool` | `true` | no |
 | <a name="input_enable_versioning"></a> [enable\_versioning](#input\_enable\_versioning) | Disable the versioning for the bucket. Default: true | `bool` | `true` | no |
-| <a name="input_secrets"></a> [secrets](#input\_secrets) | n/a | `map(any)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `null` | no |
 
 ## Outputs

--- a/modules/private_dns/README.md
+++ b/modules/private_dns/README.md
@@ -38,3 +38,53 @@ my_database                       = [<IP_ADDR>]
 ```hcl
 my_cluster = [<IP_ADDR_1>, <IP_ADDR_2>, ...]
 ```
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_opentelekomcloud"></a> [opentelekomcloud](#requirement\_opentelekomcloud) | >=1.31.5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | >=1.31.5 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [opentelekomcloud_dns_recordset_v2.a_records](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_recordset_v2) | resource |
+| [opentelekomcloud_dns_recordset_v2.aaaa_records](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_recordset_v2) | resource |
+| [opentelekomcloud_dns_recordset_v2.cname_records](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_recordset_v2) | resource |
+| [opentelekomcloud_dns_recordset_v2.mx_records](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_recordset_v2) | resource |
+| [opentelekomcloud_dns_recordset_v2.ptr_records](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_recordset_v2) | resource |
+| [opentelekomcloud_dns_recordset_v2.srv_records](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_recordset_v2) | resource |
+| [opentelekomcloud_dns_recordset_v2.txt_records](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_recordset_v2) | resource |
+| [opentelekomcloud_dns_zone_v2.private_zone](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_zone_v2) | resource |
+| [opentelekomcloud_identity_project_v3.current](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/identity_project_v3) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_a_records"></a> [a\_records](#input\_a\_records) | Map of DNS A records. Maps domains to IPv4 addresses. | `map(list(string))` | `{}` | no |
+| <a name="input_aaaa_records"></a> [aaaa\_records](#input\_aaaa\_records) | Map of DNS AAAA records. Map domains to IPv6 addresses. | `map(list(string))` | `{}` | no |
+| <a name="input_cname_records"></a> [cname\_records](#input\_cname\_records) | Map of DNS CNAME records. Map one domain to another. | `map(list(string))` | `{}` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | The domain name to create private DNS zone for. | `string` | n/a | yes |
+| <a name="input_mx_records"></a> [mx\_records](#input\_mx\_records) | Map of DNS MX records. Map domains to email servers. | `map(list(string))` | `{}` | no |
+| <a name="input_ptr_records"></a> [ptr\_records](#input\_ptr\_records) | Map of DNS SRV records. Map IP addresses to domains. | `map(list(string))` | `{}` | no |
+| <a name="input_srv_records"></a> [srv\_records](#input\_srv\_records) | Map of DNS SRV records. Record servers providing specific services. | `map(list(string))` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Common tag set for project resources | `map(string)` | `{}` | no |
+| <a name="input_txt_records"></a> [txt\_records](#input\_txt\_records) | Map of DNS TXT records. Specify text records. | `map(list(string))` | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID to associate this private DNS zone with. | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/private_dns/README.md
+++ b/modules/private_dns/README.md
@@ -73,16 +73,16 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_domain"></a> [domain](#input\_domain) | The domain name to create private DNS zone for. | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID to associate this private DNS zone with. | `string` | n/a | yes |
 | <a name="input_a_records"></a> [a\_records](#input\_a\_records) | Map of DNS A records. Maps domains to IPv4 addresses. | `map(list(string))` | `{}` | no |
 | <a name="input_aaaa_records"></a> [aaaa\_records](#input\_aaaa\_records) | Map of DNS AAAA records. Map domains to IPv6 addresses. | `map(list(string))` | `{}` | no |
 | <a name="input_cname_records"></a> [cname\_records](#input\_cname\_records) | Map of DNS CNAME records. Map one domain to another. | `map(list(string))` | `{}` | no |
-| <a name="input_domain"></a> [domain](#input\_domain) | The domain name to create private DNS zone for. | `string` | n/a | yes |
 | <a name="input_mx_records"></a> [mx\_records](#input\_mx\_records) | Map of DNS MX records. Map domains to email servers. | `map(list(string))` | `{}` | no |
 | <a name="input_ptr_records"></a> [ptr\_records](#input\_ptr\_records) | Map of DNS SRV records. Map IP addresses to domains. | `map(list(string))` | `{}` | no |
 | <a name="input_srv_records"></a> [srv\_records](#input\_srv\_records) | Map of DNS SRV records. Record servers providing specific services. | `map(list(string))` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Common tag set for project resources | `map(string)` | `{}` | no |
 | <a name="input_txt_records"></a> [txt\_records](#input\_txt\_records) | Map of DNS TXT records. Specify text records. | `map(list(string))` | `{}` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID to associate this private DNS zone with. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/public_dns/README.md
+++ b/modules/public_dns/README.md
@@ -1,5 +1,4 @@
 ## Manage your domain name records via OTC DNS
-
 Usage Example:
 
 ```hcl
@@ -45,3 +44,57 @@ my-subdomain                 = [<IP_ADDR>]
 ```hcl
 my_cluster = [<IP_ADDR_1>, <IP_ADDR_2>, ...]
 ```
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_opentelekomcloud"></a> [opentelekomcloud](#requirement\_opentelekomcloud) | >=1.31.5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | >=1.31.5 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [opentelekomcloud_dns_recordset_v2.a_records](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_recordset_v2) | resource |
+| [opentelekomcloud_dns_recordset_v2.aaaa_records](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_recordset_v2) | resource |
+| [opentelekomcloud_dns_recordset_v2.caa_records](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_recordset_v2) | resource |
+| [opentelekomcloud_dns_recordset_v2.cname_records](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_recordset_v2) | resource |
+| [opentelekomcloud_dns_recordset_v2.mx_records](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_recordset_v2) | resource |
+| [opentelekomcloud_dns_recordset_v2.ns_records](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_recordset_v2) | resource |
+| [opentelekomcloud_dns_recordset_v2.srv_records](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_recordset_v2) | resource |
+| [opentelekomcloud_dns_recordset_v2.txt_records](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_recordset_v2) | resource |
+| [opentelekomcloud_dns_zone_v2.public_zone](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_zone_v2) | resource |
+| [opentelekomcloud_identity_project_v3.current](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/identity_project_v3) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_a_records"></a> [a\_records](#input\_a\_records) | Map of DNS A records. Maps domains to IPv4 addresses. | `map(list(string))` | `{}` | no |
+| <a name="input_aaaa_records"></a> [aaaa\_records](#input\_aaaa\_records) | Map of DNS AAAA records. Map domains to IPv6 addresses. | `map(list(string))` | `{}` | no |
+| <a name="input_caa_records"></a> [caa\_records](#input\_caa\_records) | Map of DNS CAA records. Grant certificate issuing permissions to CAs. | `map(list(string))` | `{}` | no |
+| <a name="input_cname_records"></a> [cname\_records](#input\_cname\_records) | Map of DNS CNAME records. Map one domain to another. | `map(list(string))` | `{}` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | The public domain to create public DNS zone for. | `string` | n/a | yes |
+| <a name="input_email"></a> [email](#input\_email) | The email address to create public DNS zone with. | `string` | n/a | yes |
+| <a name="input_mx_records"></a> [mx\_records](#input\_mx\_records) | Map of DNS MX records. Map domains to email servers. | `map(list(string))` | `{}` | no |
+| <a name="input_ns_records"></a> [ns\_records](#input\_ns\_records) | Map of DNS NS records. Delegate subdomains to other name servers. | `map(list(string))` | `{}` | no |
+| <a name="input_srv_records"></a> [srv\_records](#input\_srv\_records) | Map of DNS SRV records. Record servers providing specific services. | `map(list(string))` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Common tag set for project resources | `map(string)` | `{}` | no |
+| <a name="input_txt_records"></a> [txt\_records](#input\_txt\_records) | Map of DNS TXT records. Specify text records. | `map(list(string))` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_dns_zone_id"></a> [dns\_zone\_id](#output\_dns\_zone\_id) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/public_dns/README.md
+++ b/modules/public_dns/README.md
@@ -80,12 +80,12 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_domain"></a> [domain](#input\_domain) | The public domain to create public DNS zone for. | `string` | n/a | yes |
+| <a name="input_email"></a> [email](#input\_email) | The email address to create public DNS zone with. | `string` | n/a | yes |
 | <a name="input_a_records"></a> [a\_records](#input\_a\_records) | Map of DNS A records. Maps domains to IPv4 addresses. | `map(list(string))` | `{}` | no |
 | <a name="input_aaaa_records"></a> [aaaa\_records](#input\_aaaa\_records) | Map of DNS AAAA records. Map domains to IPv6 addresses. | `map(list(string))` | `{}` | no |
 | <a name="input_caa_records"></a> [caa\_records](#input\_caa\_records) | Map of DNS CAA records. Grant certificate issuing permissions to CAs. | `map(list(string))` | `{}` | no |
 | <a name="input_cname_records"></a> [cname\_records](#input\_cname\_records) | Map of DNS CNAME records. Map one domain to another. | `map(list(string))` | `{}` | no |
-| <a name="input_domain"></a> [domain](#input\_domain) | The public domain to create public DNS zone for. | `string` | n/a | yes |
-| <a name="input_email"></a> [email](#input\_email) | The email address to create public DNS zone with. | `string` | n/a | yes |
 | <a name="input_mx_records"></a> [mx\_records](#input\_mx\_records) | Map of DNS MX records. Map domains to email servers. | `map(list(string))` | `{}` | no |
 | <a name="input_ns_records"></a> [ns\_records](#input\_ns\_records) | Map of DNS NS records. Delegate subdomains to other name servers. | `map(list(string))` | `{}` | no |
 | <a name="input_srv_records"></a> [srv\_records](#input\_srv\_records) | Map of DNS SRV records. Record servers providing specific services. | `map(list(string))` | `{}` | no |

--- a/modules/rds/README.md
+++ b/modules/rds/README.md
@@ -39,3 +39,85 @@ module "rds" {
 ```hcl
   db_volume_encryption = false
 ```
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_errorcheck"></a> [errorcheck](#provider\_errorcheck) | n/a |
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [errorcheck_is_valid.db_availability_zones](https://registry.terraform.io/providers/iits-consulting/errorcheck/latest/docs/resources/is_valid) | resource |
+| [errorcheck_is_valid.db_flavor_constraint](https://registry.terraform.io/providers/iits-consulting/errorcheck/latest/docs/resources/is_valid) | resource |
+| [errorcheck_is_valid.db_ha_replication_mode_constraint](https://registry.terraform.io/providers/iits-consulting/errorcheck/latest/docs/resources/is_valid) | resource |
+| [opentelekomcloud_ces_alarmrule.db_storage_alarm](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/ces_alarmrule) | resource |
+| [opentelekomcloud_kms_key_v1.db_encryption_key](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/kms_key_v1) | resource |
+| [opentelekomcloud_networking_secgroup_rule_v2.db_allow_cidr](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/networking_secgroup_rule_v2) | resource |
+| [opentelekomcloud_networking_secgroup_rule_v2.db_allow_out](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/networking_secgroup_rule_v2) | resource |
+| [opentelekomcloud_networking_secgroup_rule_v2.db_allow_secgroup](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/networking_secgroup_rule_v2) | resource |
+| [opentelekomcloud_networking_secgroup_rule_v2.db_secgroup_in](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/networking_secgroup_rule_v2) | resource |
+| [opentelekomcloud_networking_secgroup_rule_v2.db_secgroup_out](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/networking_secgroup_rule_v2) | resource |
+| [opentelekomcloud_networking_secgroup_v2.db_secgroup](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/networking_secgroup_v2) | resource |
+| [opentelekomcloud_rds_instance_v3.db_instance](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/rds_instance_v3) | resource |
+| [opentelekomcloud_vpc_eip_v1.db_eip](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/vpc_eip_v1) | resource |
+| [random_id.id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_password.db_root_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [opentelekomcloud_identity_project_v3.current](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/identity_project_v3) | data source |
+| [opentelekomcloud_kms_key_v1.db_encryption_existing_key](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/kms_key_v1) | data source |
+| [opentelekomcloud_rds_flavors_v3.db_flavor](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/rds_flavors_v3) | data source |
+| [opentelekomcloud_vpc_subnet_v1.db_subnet](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/vpc_subnet_v1) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_db_availability_zones"></a> [db\_availability\_zones](#input\_db\_availability\_zones) | Availability zones for the RDS instance. One or two zones are supported for single and primary/standby instances respectively. | `set(string)` | `[]` | no |
+| <a name="input_db_backup_days"></a> [db\_backup\_days](#input\_db\_backup\_days) | Retain time for automated backups in days. (default: 7) | `number` | `"7"` | no |
+| <a name="input_db_backup_interval"></a> [db\_backup\_interval](#input\_db\_backup\_interval) | UTC time window for automated database backups in "HH:MM-HH:MM" format. Must be at least 1 hour (default: 03:00-04:00) | `string` | `"03:00-04:00"` | no |
+| <a name="input_db_cpus"></a> [db\_cpus](#input\_db\_cpus) | Number of CPU cores desired for database nodes. (default: 2) | `string` | `"2"` | no |
+| <a name="input_db_eip_bandwidth"></a> [db\_eip\_bandwidth](#input\_db\_eip\_bandwidth) | Bandwidth of the EIP of RDS instance, can be disabled by setting to 0. (default: 0) | `number` | `0` | no |
+| <a name="input_db_flavor"></a> [db\_flavor](#input\_db\_flavor) | RDS Flavor string override. This parameter will override parameters for db\_cpu, db\_memory and db\_high\_availability. | `string` | `""` | no |
+| <a name="input_db_ha_replication_mode"></a> [db\_ha\_replication\_mode](#input\_db\_ha\_replication\_mode) | RDS data replication mode for instances with high availability (primary/standby) enabled. Defaults are async(MySQL), async(PostgreSQL) and sync(SQLServer) | `string` | `""` | no |
+| <a name="input_db_high_availability"></a> [db\_high\_availability](#input\_db\_high\_availability) | Whether a single db instance or a high available (primary/standby) db instance is desired. (default: false) | `bool` | `false` | no |
+| <a name="input_db_memory"></a> [db\_memory](#input\_db\_memory) | Amount of memory desired for database nodes in GB. (default: 4) | `number` | `4` | no |
+| <a name="input_db_parameters"></a> [db\_parameters](#input\_db\_parameters) | A map of additional parameters for the database instance. Check the DB Engine's documentation. | `map(string)` | `{}` | no |
+| <a name="input_db_port"></a> [db\_port](#input\_db\_port) | Port number for accessing the database. Default ports are: 3306(MySQL), 5432(PostgreSQL) and 1433(SQLServer) | `string` | `"default"` | no |
+| <a name="input_db_size"></a> [db\_size](#input\_db\_size) | Amount of storage desired for the database in GB. (default: 10) | `number` | `100` | no |
+| <a name="input_db_storage_alarm_threshold"></a> [db\_storage\_alarm\_threshold](#input\_db\_storage\_alarm\_threshold) | CES alarm threshold (in percent) for database storage capacity. Can be disabled by setting to 0. (default: 75) | `number` | `75` | no |
+| <a name="input_db_storage_type"></a> [db\_storage\_type](#input\_db\_storage\_type) | Type of storage desired for the database. Allowed values are COMMON (SATA) or ULTRAHIGH (SSD) (default: ULTRAHIGH) | `string` | `"ULTRAHIGH"` | no |
+| <a name="input_db_type"></a> [db\_type](#input\_db\_type) | RDS database product type. (MySQL, PostgreSQL or SQLServer) | `string` | n/a | yes |
+| <a name="input_db_version"></a> [db\_version](#input\_db\_version) | RDS database product version. | `string` | n/a | yes |
+| <a name="input_db_volume_encryption"></a> [db\_volume\_encryption](#input\_db\_volume\_encryption) | Enable OTC KMS volume encryption for the database volumes. (default: true) | `bool` | `true` | no |
+| <a name="input_db_volume_encryption_key_name"></a> [db\_volume\_encryption\_key\_name](#input\_db\_volume\_encryption\_key\_name) | If KMS volume encryption is enabled for the database volumes, use this kms key name instead of creating a new one. (default: null) | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the RDS instance. | `string` | n/a | yes |
+| <a name="input_sg_allowed_cidr"></a> [sg\_allowed\_cidr](#input\_sg\_allowed\_cidr) | CIDR ranges that are allowed to connect to the database. (default: <var.subnet\_id.cidr>) | `set(string)` | `[]` | no |
+| <a name="input_sg_allowed_secgroups"></a> [sg\_allowed\_secgroups](#input\_sg\_allowed\_secgroups) | Security groups that are allowed to connect to the database. (default: []) | `set(string)` | `[]` | no |
+| <a name="input_sg_secgroup_id"></a> [sg\_secgroup\_id](#input\_sg\_secgroup\_id) | Security group override to allow user defined security group definitions. | `string` | `""` | no |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Id of the subnet to create database cluster in. | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Common tag set for project resources | `map(string)` | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | Id of the VPC to create database cluster in. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_db_instance_ids"></a> [db\_instance\_ids](#output\_db\_instance\_ids) | n/a |
+| <a name="output_db_private_ip"></a> [db\_private\_ip](#output\_db\_private\_ip) | n/a |
+| <a name="output_db_public_ip"></a> [db\_public\_ip](#output\_db\_public\_ip) | n/a |
+| <a name="output_db_root_password"></a> [db\_root\_password](#output\_db\_root\_password) | n/a |
+| <a name="output_db_root_username"></a> [db\_root\_username](#output\_db\_root\_username) | n/a |
+| <a name="output_sg_secgroup_id"></a> [sg\_secgroup\_id](#output\_sg\_secgroup\_id) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/rds/README.md
+++ b/modules/rds/README.md
@@ -84,6 +84,11 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_db_type"></a> [db\_type](#input\_db\_type) | RDS database product type. (MySQL, PostgreSQL or SQLServer) | `string` | n/a | yes |
+| <a name="input_db_version"></a> [db\_version](#input\_db\_version) | RDS database product version. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the RDS instance. | `string` | n/a | yes |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Id of the subnet to create database cluster in. | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | Id of the VPC to create database cluster in. | `string` | n/a | yes |
 | <a name="input_db_availability_zones"></a> [db\_availability\_zones](#input\_db\_availability\_zones) | Availability zones for the RDS instance. One or two zones are supported for single and primary/standby instances respectively. | `set(string)` | `[]` | no |
 | <a name="input_db_backup_days"></a> [db\_backup\_days](#input\_db\_backup\_days) | Retain time for automated backups in days. (default: 7) | `number` | `"7"` | no |
 | <a name="input_db_backup_interval"></a> [db\_backup\_interval](#input\_db\_backup\_interval) | UTC time window for automated database backups in "HH:MM-HH:MM" format. Must be at least 1 hour (default: 03:00-04:00) | `string` | `"03:00-04:00"` | no |
@@ -98,17 +103,12 @@ No modules.
 | <a name="input_db_size"></a> [db\_size](#input\_db\_size) | Amount of storage desired for the database in GB. (default: 10) | `number` | `100` | no |
 | <a name="input_db_storage_alarm_threshold"></a> [db\_storage\_alarm\_threshold](#input\_db\_storage\_alarm\_threshold) | CES alarm threshold (in percent) for database storage capacity. Can be disabled by setting to 0. (default: 75) | `number` | `75` | no |
 | <a name="input_db_storage_type"></a> [db\_storage\_type](#input\_db\_storage\_type) | Type of storage desired for the database. Allowed values are COMMON (SATA) or ULTRAHIGH (SSD) (default: ULTRAHIGH) | `string` | `"ULTRAHIGH"` | no |
-| <a name="input_db_type"></a> [db\_type](#input\_db\_type) | RDS database product type. (MySQL, PostgreSQL or SQLServer) | `string` | n/a | yes |
-| <a name="input_db_version"></a> [db\_version](#input\_db\_version) | RDS database product version. | `string` | n/a | yes |
 | <a name="input_db_volume_encryption"></a> [db\_volume\_encryption](#input\_db\_volume\_encryption) | Enable OTC KMS volume encryption for the database volumes. (default: true) | `bool` | `true` | no |
 | <a name="input_db_volume_encryption_key_name"></a> [db\_volume\_encryption\_key\_name](#input\_db\_volume\_encryption\_key\_name) | If KMS volume encryption is enabled for the database volumes, use this kms key name instead of creating a new one. (default: null) | `string` | `null` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name of the RDS instance. | `string` | n/a | yes |
 | <a name="input_sg_allowed_cidr"></a> [sg\_allowed\_cidr](#input\_sg\_allowed\_cidr) | CIDR ranges that are allowed to connect to the database. (default: <var.subnet\_id.cidr>) | `set(string)` | `[]` | no |
 | <a name="input_sg_allowed_secgroups"></a> [sg\_allowed\_secgroups](#input\_sg\_allowed\_secgroups) | Security groups that are allowed to connect to the database. (default: []) | `set(string)` | `[]` | no |
 | <a name="input_sg_secgroup_id"></a> [sg\_secgroup\_id](#input\_sg\_secgroup\_id) | Security group override to allow user defined security group definitions. | `string` | `""` | no |
-| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Id of the subnet to create database cluster in. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Common tag set for project resources | `map(string)` | `{}` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | Id of the VPC to create database cluster in. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/snat/README.md
+++ b/modules/snat/README.md
@@ -39,3 +39,50 @@ module "snat" {
 
 - If no `network_ids` parameter is specified, the module will create the SNAT rule for its own subnet by default 
 - It is possible to create CIDR based SNAT rules via `network_cidrs` parameter
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_opentelekomcloud"></a> [opentelekomcloud](#requirement\_opentelekomcloud) | >=1.31.5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | >=1.31.5 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [opentelekomcloud_nat_gateway_v2.nat](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/nat_gateway_v2) | resource |
+| [opentelekomcloud_nat_snat_rule_v2.snat_cidr](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/nat_snat_rule_v2) | resource |
+| [opentelekomcloud_nat_snat_rule_v2.snat_subnet](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/nat_snat_rule_v2) | resource |
+| [opentelekomcloud_nat_snat_rule_v2.snat_subnet_default](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/nat_snat_rule_v2) | resource |
+| [opentelekomcloud_vpc_eip_v1.nat_ip](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/vpc_eip_v1) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix for all OTC resource names | `string` | n/a | yes |
+| <a name="input_nat_bandwidth"></a> [nat\_bandwidth](#input\_nat\_bandwidth) | The dedicated bandwidth assigned to the NAT Gateway. (default: 100) | `string` | `100` | no |
+| <a name="input_nat_size"></a> [nat\_size](#input\_nat\_size) | The size of the NAT Gateway. Allowed values are "1", "2", "3" and "4". (default: "1") | `string` | `"1"` | no |
+| <a name="input_network_cidrs"></a> [network\_cidrs](#input\_network\_cidrs) | List of CIDRs that will use the SNAT gateway. (default: []) | `set(string)` | `[]` | no |
+| <a name="input_network_ids"></a> [network\_ids](#input\_network\_ids) | List of subnet that will use the SNAT gateway. (default: var.subnet\_id) | `set(string)` | `[]` | no |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Id of the subnet to place SNAT gateway in. | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Common tag set for OTC resources | `map(any)` | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | Id of the VPC to create SNAT gateway in. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_nat_ip"></a> [nat\_ip](#output\_nat\_ip) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/snat/README.md
+++ b/modules/snat/README.md
@@ -72,13 +72,13 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix for all OTC resource names | `string` | n/a | yes |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Id of the subnet to place SNAT gateway in. | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | Id of the VPC to create SNAT gateway in. | `string` | n/a | yes |
 | <a name="input_nat_bandwidth"></a> [nat\_bandwidth](#input\_nat\_bandwidth) | The dedicated bandwidth assigned to the NAT Gateway. (default: 100) | `string` | `100` | no |
 | <a name="input_nat_size"></a> [nat\_size](#input\_nat\_size) | The size of the NAT Gateway. Allowed values are "1", "2", "3" and "4". (default: "1") | `string` | `"1"` | no |
 | <a name="input_network_cidrs"></a> [network\_cidrs](#input\_network\_cidrs) | List of CIDRs that will use the SNAT gateway. (default: []) | `set(string)` | `[]` | no |
 | <a name="input_network_ids"></a> [network\_ids](#input\_network\_ids) | List of subnet that will use the SNAT gateway. (default: var.subnet\_id) | `set(string)` | `[]` | no |
-| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Id of the subnet to place SNAT gateway in. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Common tag set for OTC resources | `map(any)` | `{}` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | Id of the VPC to create SNAT gateway in. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -1,4 +1,4 @@
-##Module to auto create VPC and multiple Subnet
+# Module to auto create VPC and multiple Subnet
 
 Usage example
 ```hcl
@@ -13,3 +13,45 @@ module "vpc" {
   tags       = {}
 }
 ```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [opentelekomcloud_vpc_subnet_v1.subnets](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/vpc_subnet_v1) | resource |
+| [opentelekomcloud_vpc_v1.vpc](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/vpc_v1) | resource |
+| [opentelekomcloud_identity_project_v3.current](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/data-sources/identity_project_v3) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | IP range of the VPC | `string` | n/a | yes |
+| <a name="input_dns_config"></a> [dns\_config](#input\_dns\_config) | Common Domain Name Server list for all subnets | `list(string)` | <pre>[<br>  "100.125.4.25",<br>  "100.125.129.199"<br>]</pre> | no |
+| <a name="input_enable_shared_snat"></a> [enable\_shared\_snat](#input\_enable\_shared\_snat) | Enable the shared SNAT capability on VPCs in eu-de region. (default: true) | `bool` | `true` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the VPC. | `string` | n/a | yes |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnet names and their cidr ranges. | `map(string)` | <pre>{<br>  "default-subnet": "default_cidr"<br>}</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Common tag set for project resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_subnets"></a> [subnets](#output\_subnets) | n/a |
+| <a name="output_vpc"></a> [vpc](#output\_vpc) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -47,11 +47,11 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | IP range of the VPC | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name of the VPC. | `string` | n/a | yes |
+| <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | IP range of the VPC | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_dns_config"></a> [dns\_config](#input\_dns\_config) | Common Domain Name Server list for all subnets | `list(string)` | <pre>[<br>  "100.125.4.25",<br>  "100.125.129.199"<br>]</pre> | no |
 | <a name="input_enable_shared_snat"></a> [enable\_shared\_snat](#input\_enable\_shared\_snat) | Enable the shared SNAT capability on VPCs in eu-de region. (default: true) | `bool` | `true` | no |
-| <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnet names and their cidr ranges. | `map(string)` | <pre>{<br>  "default-subnet": "default_cidr"<br>}</pre> | no |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnet names and their cidr ranges. | `map(string)` | <pre>{<br>  "database-subnet": "",<br>  "jumphost-subnet": "",<br>  "kubernetes-subnet": ""<br>}</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Common tag set for project resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -42,9 +42,9 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | IP range of the VPC | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the VPC. | `string` | n/a | yes |
 | <a name="input_dns_config"></a> [dns\_config](#input\_dns\_config) | Common Domain Name Server list for all subnets | `list(string)` | <pre>[<br>  "100.125.4.25",<br>  "100.125.129.199"<br>]</pre> | no |
 | <a name="input_enable_shared_snat"></a> [enable\_shared\_snat](#input\_enable\_shared\_snat) | Enable the shared SNAT capability on VPCs in eu-de region. (default: true) | `bool` | `true` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name of the VPC. | `string` | n/a | yes |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnet names and their cidr ranges. | `map(string)` | <pre>{<br>  "default-subnet": "default_cidr"<br>}</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Common tag set for project resources | `map(string)` | `{}` | no |
 

--- a/modules/vpn/README.md
+++ b/modules/vpn/README.md
@@ -1,4 +1,4 @@
-## VPN Module
+# VPN Module
 
 A module designed to create a vpn tunnel. 
 
@@ -51,3 +51,60 @@ module "vpn_tunnel" {
 
 Notes:
 - example of a full vpn tunnel to be found in the [Terratest section](https://github.com/iits-consulting/terraform-opentelekomcloud-project-factory/tree/master/terratest/vpn)  
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_opentelekomcloud"></a> [opentelekomcloud](#requirement\_opentelekomcloud) | 1.34.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | 1.34.1 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [opentelekomcloud_vpnaas_endpoint_group_v2.local_peer](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/1.34.1/docs/resources/vpnaas_endpoint_group_v2) | resource |
+| [opentelekomcloud_vpnaas_endpoint_group_v2.remote_peer](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/1.34.1/docs/resources/vpnaas_endpoint_group_v2) | resource |
+| [opentelekomcloud_vpnaas_ike_policy_v2.ike_policy](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/1.34.1/docs/resources/vpnaas_ike_policy_v2) | resource |
+| [opentelekomcloud_vpnaas_ipsec_policy_v2.ipsec_policy](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/1.34.1/docs/resources/vpnaas_ipsec_policy_v2) | resource |
+| [opentelekomcloud_vpnaas_service_v2.vpnaas_service](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/1.34.1/docs/resources/vpnaas_service_v2) | resource |
+| [opentelekomcloud_vpnaas_site_connection_v2.tunnel_connection](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/1.34.1/docs/resources/vpnaas_site_connection_v2) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_dpd"></a> [dpd](#input\_dpd) | Dead peer detection (true = hold (default) false = disabled). | `bool` | `true` | no |
+| <a name="input_local_router"></a> [local\_router](#input\_local\_router) | VPC id of the vpnaas service. | `string` | n/a | yes |
+| <a name="input_local_subnets"></a> [local\_subnets](#input\_local\_subnets) | Local subnet CIDR ranges. | `set(string)` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Prefix for all OTC resource names | `string` | n/a | yes |
+| <a name="input_psk"></a> [psk](#input\_psk) | Pre shared key for vpn tunnel. | `string` | n/a | yes |
+| <a name="input_remote_gateway"></a> [remote\_gateway](#input\_remote\_gateway) | Remote endpoint IPv4 address. | `string` | n/a | yes |
+| <a name="input_remote_subnets"></a> [remote\_subnets](#input\_remote\_subnets) | Remote subnet CIDR ranges. | `set(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Common tag set for project resources | `map(string)` | n/a | yes |
+| <a name="input_vpn_ike_policy_auth_algorithm"></a> [vpn\_ike\_policy\_auth\_algorithm](#input\_vpn\_ike\_policy\_auth\_algorithm) | Authentication hash algorithm | `string` | n/a | yes |
+| <a name="input_vpn_ike_policy_dh_algorithm"></a> [vpn\_ike\_policy\_dh\_algorithm](#input\_vpn\_ike\_policy\_dh\_algorithm) | Diffie-Hellman key exchange algorithm | `string` | n/a | yes |
+| <a name="input_vpn_ike_policy_encryption_algorithm"></a> [vpn\_ike\_policy\_encryption\_algorithm](#input\_vpn\_ike\_policy\_encryption\_algorithm) | Encryption algorithm | `string` | n/a | yes |
+| <a name="input_vpn_ike_policy_lifetime"></a> [vpn\_ike\_policy\_lifetime](#input\_vpn\_ike\_policy\_lifetime) | Lifetime of the security association in seconds. | `number` | `86400` | no |
+| <a name="input_vpn_ipsec_policy_auth_algorithm"></a> [vpn\_ipsec\_policy\_auth\_algorithm](#input\_vpn\_ipsec\_policy\_auth\_algorithm) | Authentication hash algorithm | `string` | n/a | yes |
+| <a name="input_vpn_ipsec_policy_encryption_algorithm"></a> [vpn\_ipsec\_policy\_encryption\_algorithm](#input\_vpn\_ipsec\_policy\_encryption\_algorithm) | Encryption algorithm | `string` | n/a | yes |
+| <a name="input_vpn_ipsec_policy_lifetime"></a> [vpn\_ipsec\_policy\_lifetime](#input\_vpn\_ipsec\_policy\_lifetime) | Lifetime of the security association in seconds. | `number` | `3600` | no |
+| <a name="input_vpn_ipsec_policy_pfs"></a> [vpn\_ipsec\_policy\_pfs](#input\_vpn\_ipsec\_policy\_pfs) | The perfect forward secrecy mode | `string` | n/a | yes |
+| <a name="input_vpn_ipsec_policy_protocol"></a> [vpn\_ipsec\_policy\_protocol](#input\_vpn\_ipsec\_policy\_protocol) | The security protocol used for IPSec to transmit and encapsulate user data. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_vpn_tunnel_gateway"></a> [vpn\_tunnel\_gateway](#output\_vpn\_tunnel\_gateway) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/vpn/README.md
+++ b/modules/vpn/README.md
@@ -84,7 +84,6 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_dpd"></a> [dpd](#input\_dpd) | Dead peer detection (true = hold (default) false = disabled). | `bool` | `true` | no |
 | <a name="input_local_router"></a> [local\_router](#input\_local\_router) | VPC id of the vpnaas service. | `string` | n/a | yes |
 | <a name="input_local_subnets"></a> [local\_subnets](#input\_local\_subnets) | Local subnet CIDR ranges. | `set(string)` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Prefix for all OTC resource names | `string` | n/a | yes |
@@ -95,12 +94,13 @@ No modules.
 | <a name="input_vpn_ike_policy_auth_algorithm"></a> [vpn\_ike\_policy\_auth\_algorithm](#input\_vpn\_ike\_policy\_auth\_algorithm) | Authentication hash algorithm | `string` | n/a | yes |
 | <a name="input_vpn_ike_policy_dh_algorithm"></a> [vpn\_ike\_policy\_dh\_algorithm](#input\_vpn\_ike\_policy\_dh\_algorithm) | Diffie-Hellman key exchange algorithm | `string` | n/a | yes |
 | <a name="input_vpn_ike_policy_encryption_algorithm"></a> [vpn\_ike\_policy\_encryption\_algorithm](#input\_vpn\_ike\_policy\_encryption\_algorithm) | Encryption algorithm | `string` | n/a | yes |
-| <a name="input_vpn_ike_policy_lifetime"></a> [vpn\_ike\_policy\_lifetime](#input\_vpn\_ike\_policy\_lifetime) | Lifetime of the security association in seconds. | `number` | `86400` | no |
 | <a name="input_vpn_ipsec_policy_auth_algorithm"></a> [vpn\_ipsec\_policy\_auth\_algorithm](#input\_vpn\_ipsec\_policy\_auth\_algorithm) | Authentication hash algorithm | `string` | n/a | yes |
 | <a name="input_vpn_ipsec_policy_encryption_algorithm"></a> [vpn\_ipsec\_policy\_encryption\_algorithm](#input\_vpn\_ipsec\_policy\_encryption\_algorithm) | Encryption algorithm | `string` | n/a | yes |
-| <a name="input_vpn_ipsec_policy_lifetime"></a> [vpn\_ipsec\_policy\_lifetime](#input\_vpn\_ipsec\_policy\_lifetime) | Lifetime of the security association in seconds. | `number` | `3600` | no |
 | <a name="input_vpn_ipsec_policy_pfs"></a> [vpn\_ipsec\_policy\_pfs](#input\_vpn\_ipsec\_policy\_pfs) | The perfect forward secrecy mode | `string` | n/a | yes |
 | <a name="input_vpn_ipsec_policy_protocol"></a> [vpn\_ipsec\_policy\_protocol](#input\_vpn\_ipsec\_policy\_protocol) | The security protocol used for IPSec to transmit and encapsulate user data. | `string` | n/a | yes |
+| <a name="input_dpd"></a> [dpd](#input\_dpd) | Dead peer detection (true = hold (default) false = disabled). | `bool` | `true` | no |
+| <a name="input_vpn_ike_policy_lifetime"></a> [vpn\_ike\_policy\_lifetime](#input\_vpn\_ike\_policy\_lifetime) | Lifetime of the security association in seconds. | `number` | `86400` | no |
+| <a name="input_vpn_ipsec_policy_lifetime"></a> [vpn\_ipsec\_policy\_lifetime](#input\_vpn\_ipsec\_policy\_lifetime) | Lifetime of the security association in seconds. | `number` | `3600` | no |
 
 ## Outputs
 

--- a/modules/waf/README.md
+++ b/modules/waf/README.md
@@ -25,5 +25,53 @@ module "waf" {
 }
 ```
 
-Notes:
-- This module requires OTC Terraform Provider version 1.28.2 or newer.
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_opentelekomcloud"></a> [opentelekomcloud](#requirement\_opentelekomcloud) | >=1.31.5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_errorcheck"></a> [errorcheck](#provider\_errorcheck) | n/a |
+| <a name="provider_opentelekomcloud"></a> [opentelekomcloud](#provider\_opentelekomcloud) | >=1.31.5 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [errorcheck_is_valid.certificate_private_key_required](https://registry.terraform.io/providers/iits-consulting/errorcheck/latest/docs/resources/is_valid) | resource |
+| [errorcheck_is_valid.certificate_private_key_validation](https://registry.terraform.io/providers/iits-consulting/errorcheck/latest/docs/resources/is_valid) | resource |
+| [errorcheck_is_valid.certificate_required](https://registry.terraform.io/providers/iits-consulting/errorcheck/latest/docs/resources/is_valid) | resource |
+| [errorcheck_is_valid.certificate_validation](https://registry.terraform.io/providers/iits-consulting/errorcheck/latest/docs/resources/is_valid) | resource |
+| [opentelekomcloud_dns_recordset_v2.waf](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/dns_recordset_v2) | resource |
+| [opentelekomcloud_waf_certificate_v1.certificate](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/waf_certificate_v1) | resource |
+| [opentelekomcloud_waf_domain_v1.domain](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/waf_domain_v1) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_certificate"></a> [certificate](#input\_certificate) | Signed certificate in PEM format for the domain(s). | `string` | `""` | no |
+| <a name="input_certificate_private_key"></a> [certificate\_private\_key](#input\_certificate\_private\_key) | Private key of the certificate in PEM format for the domain(s). | `string` | `""` | no |
+| <a name="input_client_insecure"></a> [client\_insecure](#input\_client\_insecure) | Use HTTP (insecure) protocol between WAF and client. (default: false). | `bool` | `false` | no |
+| <a name="input_dns_zone_id"></a> [dns\_zone\_id](#input\_dns\_zone\_id) | OTC DNS zone to create the WAF CNAME records in. | `string` | n/a | yes |
+| <a name="input_domain"></a> [domain](#input\_domain) | Domain name to create DNS and WAF resources for. | `string` | n/a | yes |
+| <a name="input_server_addresses"></a> [server\_addresses](#input\_server\_addresses) | Set of destination endpoint(s) external IP address(es) and ports they are listening on in format <ip\_addr>:<port> | `set(string)` | n/a | yes |
+| <a name="input_server_insecure"></a> [server\_insecure](#input\_server\_insecure) | Use HTTP (insecure) protocol between WAF and destination endpoint(s). (default: false). | `bool` | `false` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Common tag set for PEGA project resources | `map(string)` | `{}` | no |
+| <a name="input_tls_cipher"></a> [tls\_cipher](#input\_tls\_cipher) | Cipher suite to use with TLS. Accepted values are "cipher\_default", "cipher\_1", "cipher\_2" and "cipher\_3". (default: cipher\_1) | `string` | `"cipher_1"` | no |
+| <a name="input_tls_version"></a> [tls\_version](#input\_tls\_version) | TLS version to enforce on client. Accepted values are "TLS v1.1" and "TLS v1.2". (default: TLS v1.2) | `string` | `"TLS v1.2"` | no |
+| <a name="input_waf_policy_id"></a> [waf\_policy\_id](#input\_waf\_policy\_id) | WAF policy ID to associate with the domains. (default: OTC will create a default policy) | `string` | `null` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/waf/README.md
+++ b/modules/waf/README.md
@@ -59,12 +59,12 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_certificate"></a> [certificate](#input\_certificate) | Signed certificate in PEM format for the domain(s). | `string` | `""` | no |
-| <a name="input_certificate_private_key"></a> [certificate\_private\_key](#input\_certificate\_private\_key) | Private key of the certificate in PEM format for the domain(s). | `string` | `""` | no |
-| <a name="input_client_insecure"></a> [client\_insecure](#input\_client\_insecure) | Use HTTP (insecure) protocol between WAF and client. (default: false). | `bool` | `false` | no |
 | <a name="input_dns_zone_id"></a> [dns\_zone\_id](#input\_dns\_zone\_id) | OTC DNS zone to create the WAF CNAME records in. | `string` | n/a | yes |
 | <a name="input_domain"></a> [domain](#input\_domain) | Domain name to create DNS and WAF resources for. | `string` | n/a | yes |
 | <a name="input_server_addresses"></a> [server\_addresses](#input\_server\_addresses) | Set of destination endpoint(s) external IP address(es) and ports they are listening on in format <ip\_addr>:<port> | `set(string)` | n/a | yes |
+| <a name="input_certificate"></a> [certificate](#input\_certificate) | Signed certificate in PEM format for the domain(s). | `string` | `""` | no |
+| <a name="input_certificate_private_key"></a> [certificate\_private\_key](#input\_certificate\_private\_key) | Private key of the certificate in PEM format for the domain(s). | `string` | `""` | no |
+| <a name="input_client_insecure"></a> [client\_insecure](#input\_client\_insecure) | Use HTTP (insecure) protocol between WAF and client. (default: false). | `bool` | `false` | no |
 | <a name="input_server_insecure"></a> [server\_insecure](#input\_server\_insecure) | Use HTTP (insecure) protocol between WAF and destination endpoint(s). (default: false). | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Common tag set for PEGA project resources | `map(string)` | `{}` | no |
 | <a name="input_tls_cipher"></a> [tls\_cipher](#input\_tls\_cipher) | Cipher suite to use with TLS. Accepted values are "cipher\_default", "cipher\_1", "cipher\_2" and "cipher\_3". (default: cipher\_1) | `string` | `"cipher_1"` | no |

--- a/tf_state_backend/README.md
+++ b/tf_state_backend/README.md
@@ -33,3 +33,6 @@ backend "s3" {
   skip_credentials_validation = true
 }
 ```
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
Here we try to introduce automatic updates to parts of the documentation
of the different modules. We leave most of the README files as-is and
use `terraform-docs` to inject information into them.

This PR also includes a GH action the automates this process in PRs