### PR TITLE
Obs restricted

### DIFF
--- a/modules/obs_restricted/group.tf
+++ b/modules/obs_restricted/group.tf
@@ -1,32 +1,70 @@
-data "opentelekomcloud_identity_project_v3" "toplevel" {
-  name = var.region
+resource "opentelekomcloud_identity_group_v3" "obs_group" {
+  name        = "${var.bucket_name}-group"
+  description = "OBS bucket access group for ${var.bucket_name}."
 }
 
 data "opentelekomcloud_identity_project_v3" "obs_project" {
   name = "MOS"
 }
 
-data "opentelekomcloud_identity_role_v3" "obs_read_role" {
-  name = "obs_b_list"
-}
-
-resource "opentelekomcloud_identity_group_v3" "obs_group" {
-  name        = "${var.bucket_name}-group"
-  description = "OBS bucket access group for ${var.bucket_name}."
+resource "opentelekomcloud_identity_role_v3" "bucket_access" {
+  display_name  = "${var.bucket_name}-obs-role"
+  description   = "OBS bucket access role for ${var.bucket_name}."
+  display_layer = "domain"
+  statement {
+    effect = "Allow"
+    resource = [
+      "obs:*:*:object:${opentelekomcloud_obs_bucket.bucket.id}/*",
+      "obs:*:*:bucket:${opentelekomcloud_obs_bucket.bucket.id}"
+    ]
+    action = [
+      "obs:bucket:ListAllMybuckets",
+      "obs:bucket:HeadBucket",
+      "obs:bucket:ListBucket",
+      "obs:bucket:GetBucketLocation",
+      "obs:object:GetObject",
+      "obs:object:GetObjectVersion",
+      "obs:object:PutObject",
+      "obs:object:DeleteObject",
+      "obs:object:DeleteObjectVersion",
+      "obs:object:ListMultipartUploadParts",
+      "obs:object:AbortMultipartUpload",
+      "obs:object:GetObjectAcl",
+      "obs:object:GetObjectVersionAcl",
+    ]
+  }
 }
 
 resource "opentelekomcloud_identity_role_assignment_v3" "obs_role_to_obs_group" {
   group_id   = opentelekomcloud_identity_group_v3.obs_group.id
   project_id = data.opentelekomcloud_identity_project_v3.obs_project.id
-  role_id    = data.opentelekomcloud_identity_role_v3.obs_read_role.id
+  role_id    = opentelekomcloud_identity_role_v3.bucket_access.id
 }
 
-data "opentelekomcloud_identity_role_v3" "kms_admin" {
-  name = "kms_adm"
+data "opentelekomcloud_identity_project_v3" "current" {}
+
+resource "opentelekomcloud_identity_role_v3" "kms_access" {
+  display_name  = "${var.bucket_name}-kms-role"
+  description   = "KMS encryption access role for ${var.bucket_name}."
+  display_layer = "project"
+  statement {
+    effect = "Allow"
+    resource = [
+      "KMS:*:*:KeyId:${opentelekomcloud_kms_key_v1.bucket_kms_key.id}"
+    ]
+    action = [
+      "kms:cmk:list",
+      "kms:cmk:get",
+      "kms:cmk:generate",
+      "kms:dek:create",
+      "kms:cmk:crypto",
+      "kms:dek:crypto",
+    ]
+  }
 }
 
 resource "opentelekomcloud_identity_role_assignment_v3" "kms_adm_to_obs_group" {
   group_id   = opentelekomcloud_identity_group_v3.obs_group.id
-  project_id = data.opentelekomcloud_identity_project_v3.toplevel.id
-  role_id    = data.opentelekomcloud_identity_role_v3.kms_admin.id
+  project_id = data.opentelekomcloud_identity_project_v3.current.id
+  role_id    = opentelekomcloud_identity_role_v3.kms_access.id
 }

--- a/modules/obs_restricted/group.tf
+++ b/modules/obs_restricted/group.tf
@@ -43,6 +43,14 @@ resource "opentelekomcloud_identity_role_assignment_v3" "obs_role_to_obs_group" 
 
 data "opentelekomcloud_identity_project_v3" "current" {}
 
+resource "errorcheck_is_valid" "provider_project_constraint" {
+  name = "Check if the provider is correctly set to top level project."
+  test = {
+    assert        = data.opentelekomcloud_identity_project_v3.current.name == data.opentelekomcloud_identity_project_v3.current.region
+    error_message = "ERROR! This module requires the provider project (tenant_name) to be a region level project. See README.md for more information."
+  }
+}
+
 resource "opentelekomcloud_identity_role_v3" "kms_access" {
   display_name  = "${var.bucket_name}-kms-role"
   description   = "KMS encryption access role for ${var.bucket_name}."

--- a/modules/obs_restricted/main.tf
+++ b/modules/obs_restricted/main.tf
@@ -10,12 +10,6 @@ resource "opentelekomcloud_kms_key_v1" "bucket_kms_key" {
   tags            = var.tags
 }
 
-resource "opentelekomcloud_kms_grant_v1" "obs_user" {
-  key_id            = opentelekomcloud_kms_key_v1.bucket_kms_key.id
-  grantee_principal = opentelekomcloud_identity_user_v3.user.id
-  operations        = ["create-datakey", "encrypt-datakey", "decrypt-datakey", "describe-key"]
-}
-
 resource "opentelekomcloud_obs_bucket" "bucket" {
   bucket     = var.bucket_name
   acl        = "private"
@@ -25,30 +19,4 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
     kms_key_id = opentelekomcloud_kms_key_v1.bucket_kms_key.id
   }
   tags = var.tags
-}
-
-resource "opentelekomcloud_obs_bucket_policy" "bucket_policy" {
-  bucket = opentelekomcloud_obs_bucket.bucket.id
-  policy = jsonencode({
-    Statement = [
-      {
-        Sid    = "UserObjectAccess"
-        Effect = "Allow"
-        Principal = {
-          ID = ["domain/${opentelekomcloud_identity_user_v3.user.domain_id}:user/${opentelekomcloud_identity_user_v3.user.id}"]
-        }
-        Action   = ["*"]
-        Resource = ["${opentelekomcloud_obs_bucket.bucket.bucket}/*"]
-      },
-      {
-        Sid    = "UserBucketAccess"
-        Effect = "Allow"
-        Principal = {
-          ID = ["domain/${opentelekomcloud_identity_user_v3.user.domain_id}:user/${opentelekomcloud_identity_user_v3.user.id}"]
-        }
-        Action   = ["*"]
-        Resource = [opentelekomcloud_obs_bucket.bucket.bucket]
-      },
-    ]
-  })
 }

--- a/modules/obs_restricted/variables.tf
+++ b/modules/obs_restricted/variables.tf
@@ -13,16 +13,6 @@ variable "enable_versioning" {
   default     = true
 }
 
-variable "region" {
-  type        = string
-  description = "OTC region for the project: eu-de(default) or eu-nl"
-  default     = "eu-de"
-  validation {
-    condition     = contains(["eu-de", "eu-nl"], var.region)
-    error_message = "Allowed values for region are \"eu-de\" and \"eu-nl\"."
-  }
-}
-
 variable "tags" {
   type    = map(string)
   default = null

--- a/modules/obs_restricted/versions.tf
+++ b/modules/obs_restricted/versions.tf
@@ -4,5 +4,8 @@ terraform {
       source  = "opentelekomcloud/opentelekomcloud"
       version = ">=1.31.5"
     }
+    errorcheck = {
+      source = "iits-consulting/errorcheck"
+    }
   }
 }


### PR DESCRIPTION
- Remove bucket policy to handle permissions over IAM directly
- Remove KMS grant to handle permissions over IAM directly
- Change IAM permissions to target only the specific KMS and OBS resources
- Change IAM permissions to be more strict with allowed actions
- Remove unnecessary region variable
- Add provider check to ensure region level provider is used