### PR TITLE
VPC: Simplified the subnets output

### DIFF
--- a/modules/vpc/output.tf
+++ b/modules/vpc/output.tf
@@ -3,8 +3,5 @@ output "vpc" {
 }
 
 output "subnets" {
-  value = { for name, subnet in opentelekomcloud_vpc_subnet_v1.subnets : name => {
-    id        = subnet.id
-    subnet_id = subnet.subnet_id
-  } }
+  value = opentelekomcloud_vpc_subnet_v1.subnets
 }


### PR DESCRIPTION
- VPC: Simplified the subnets output while allowing all subnet attributes to be exported outside the module.