### PR TITLE
cce: fix logical flaw in local var autoscaler_node_min

### DIFF
--- a/modules/cce/variables.tf
+++ b/modules/cce/variables.tf
@@ -210,7 +210,7 @@ variable "autoscaler_node_min" {
 
 locals {
   // Lower bound of servers to always keep (default: <node_count>)
-  autoscaler_node_min = var.autoscaler_node_min != null ? var.node_count : var.autoscaler_node_min
+  autoscaler_node_min = var.autoscaler_node_min == null ? var.node_count : var.autoscaler_node_min
 }
 
 variable "autoscaler_version" {


### PR DESCRIPTION
## problem
setting variable `autoscaler_node_min = 3` always sets `min_node_count` to `1` in the created node pool(s)
so having more than 1 node at minimum per node pool is not possible

## cause
I think there is a minor typo in the logic in https://github.com/iits-consulting/terraform-opentelekomcloud-project-factory/blob/master/modules/cce/variables.tf#L213

## test
I tested this locally and changing the operand fixed the problem