### PR TITLE
Fixes to reduce spurious diffs caused by opentelekomcloud_identity_role_assignment_v3 resources.

### DIFF
--- a/modules/cert_manager/cert_manager.tf
+++ b/modules/cert_manager/cert_manager.tf
@@ -30,7 +30,7 @@ resource "helm_release" "cert-manager" {
       clusterIssuers = {
         email = var.email
         otcDNS = {
-          region    = data.opentelekomcloud_identity_project_v3.toplevel.name
+          region    = data.opentelekomcloud_identity_project_v3.current.region
           accessKey = opentelekomcloud_identity_credential_v3.user_aksk.access
           secretKey = opentelekomcloud_identity_credential_v3.user_aksk.secret
         }

--- a/modules/cert_manager/otc_user.tf
+++ b/modules/cert_manager/otc_user.tf
@@ -1,9 +1,5 @@
 data "opentelekomcloud_identity_project_v3" "current" {}
 
-data "opentelekomcloud_identity_project_v3" "toplevel" {
-  name = data.opentelekomcloud_identity_project_v3.current.region
-}
-
 resource "opentelekomcloud_identity_user_v3" "user" {
   name    = var.username
   enabled = true
@@ -20,8 +16,11 @@ resource "opentelekomcloud_identity_group_v3" "dns_admin_group" {
 
 resource "opentelekomcloud_identity_role_assignment_v3" "dns_admin_role_to_dns_group" {
   group_id   = opentelekomcloud_identity_group_v3.dns_admin_group.id
-  project_id = data.opentelekomcloud_identity_project_v3.toplevel.id
+  project_id = data.opentelekomcloud_identity_project_v3.current.name == data.opentelekomcloud_identity_project_v3.current.region ? data.opentelekomcloud_identity_project_v3.current.id : data.opentelekomcloud_identity_project_v3.current.parent_id
   role_id    = data.opentelekomcloud_identity_role_v3.dns_admin_role.id
+  lifecycle {
+    ignore_changes = [project_id]
+  }
 }
 
 resource "opentelekomcloud_identity_group_membership_v3" "user_to_dns_admin_group" {

--- a/modules/obs_restricted/group.tf
+++ b/modules/obs_restricted/group.tf
@@ -48,6 +48,9 @@ resource "opentelekomcloud_identity_role_assignment_v3" "obs_role_to_obs_group" 
   group_id   = opentelekomcloud_identity_group_v3.obs_group.id
   project_id = data.opentelekomcloud_identity_project_v3.obs_project.id
   role_id    = opentelekomcloud_identity_role_v3.bucket_access.id
+  lifecycle {
+    ignore_changes = [project_id]
+  }
 }
 
 data "opentelekomcloud_identity_project_v3" "current" {}
@@ -89,4 +92,7 @@ resource "opentelekomcloud_identity_role_assignment_v3" "kms_adm_to_obs_group" {
   group_id   = opentelekomcloud_identity_group_v3.obs_group.id
   project_id = data.opentelekomcloud_identity_project_v3.current.id
   role_id    = opentelekomcloud_identity_role_v3.kms_access.id
+  lifecycle {
+    ignore_changes = [project_id]
+  }
 }


### PR DESCRIPTION
- cert_manager: remove secondary data source in favor of using parent_id
- cert_manager: add project_id to ignore list for opentelekomcloud_identity_role_assignment_v3 resources to reduce number of spurious diffs caused by it
- obs_restricted: add project_id to ignore list for opentelekomcloud_identity_role_assignment_v3 resources to reduce number of spurious diffs caused by it